### PR TITLE
SUI-98 Removed Let's Encrypt configuration

### DIFF
--- a/app-host/infra/yarp.tmpl.yaml
+++ b/app-host/infra/yarp.tmpl.yaml
@@ -16,7 +16,7 @@ properties:
       external: true
       targetPort: {{ targetPortOrDefault 5443 }}
       transport: http
-      allowInsecure: true
+      allowInsecure: false
     registries:
       - server: {{ .Env.AZURE_CONTAINER_REGISTRY_ENDPOINT }}
         identity: {{ .Env.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID }}

--- a/yarp/Yarp/Program.cs
+++ b/yarp/Yarp/Program.cs
@@ -16,14 +16,6 @@ else
 {
     builder.Services.AddReverseProxy()
         .LoadFromConfig(builder.Configuration.GetSection("ReverseProxy"));
-    
-    builder.WebHost.ConfigureKestrel(kestrel =>
-    {
-        kestrel.ListenAnyIP(5443,
-            portOptions => { portOptions.UseHttps(h => { h.UseLettuceEncrypt(kestrel.ApplicationServices); }); });
-    });
-    
-    builder.Services.AddLettuceEncrypt();
 }
 
 var app = builder.Build();

--- a/yarp/Yarp/Properties/launchSettings.json
+++ b/yarp/Yarp/Properties/launchSettings.json
@@ -4,7 +4,7 @@
 			"commandName": "Project",
 			"dotnetRunMessages": true,
 			"launchBrowser": false,
-			"applicationUrl": "http://localhost:5000;https://*:5443",
+			"applicationUrl": "http://localhost:5000",
 			"environmentVariables": {
 				"ASPNETCORE_ENVIRONMENT": "Development"
 			}

--- a/yarp/Yarp/Yarp.csproj
+++ b/yarp/Yarp/Yarp.csproj
@@ -4,8 +4,6 @@
 		<PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
 		<PackageReference Include="DotNetEnv" />
 		<PackageReference Include="Yarp.ReverseProxy" />
-		<PackageReference Include="LettuceEncrypt" />
-		<PackageReference Include="LettuceEncrypt.Azure" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery.Yarp" />
 		<PackageReference Include="Microsoft.Extensions.ServiceDiscovery" />

--- a/yarp/Yarp/appsettings.Development.json
+++ b/yarp/Yarp/appsettings.Development.json
@@ -4,11 +4,5 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
-  },
-  "LettuceEncrypt": {
-    "AcceptTermsOfService": true,
-    "UseStagingServer": true,
-    "DomainNames": [ "localhost" ],
-    "EmailAddress": "it-admin@localhost"
   }
 }

--- a/yarp/Yarp/appsettings.json
+++ b/yarp/Yarp/appsettings.json
@@ -27,11 +27,5 @@
 				}
 			}
 		}
-	},
-	"LettuceEncrypt": {
-		"AcceptTermsOfService": true,
-		"UseStagingServer": true,
-		"DomainNames": [ "localhost" ],
-		"EmailAddress": "it-admin@localhost"
 	}
 }


### PR DESCRIPTION
Removed configuration due to the requirement of a public domain being needed to generate a certification.

So, since the private endpoint is secure with TLS/SSL we are opting for this.