### PR TITLE
Feat: 146 client watcher configurations

### DIFF
--- a/README_Clients_User_Manual.md
+++ b/README_Clients_User_Manual.md
@@ -1,0 +1,51 @@
+# Readme for downloading and running the SUI Client Watcher tools from NuGet source
+
+## Prerequisites
+- .NET9 SDK installed on the machine running this application.
+- Access to a terminal or command prompt.
+
+## Downloading from Nuget source
+
+To use these tools, you can install it from a NuGet source using the following command:
+
+For the DBS Client Watcher:
+
+```bash
+dotnet tool install --global DFE.SUI.DBS.Client.Watcher --add-source <url to nuget source>
+```
+
+For the Client Watcher:
+```bash
+dotnet tool install --global DFE.SUI.Client.Watcher --add-source <url to nuget source>
+```
+
+## Running the watcher tool
+To run the tool, you can use the following command:
+
+For the Client Watcher:
+```bash
+suiw <inputDirectory> <outputDirectory> <absoluteUrlToMatchingService>
+```
+
+For the DBS Client Watcher:
+```bash
+suidbsw <inputDirectory> <outputDirectory>
+```
+
+## Update the tools
+To update the tools, you can use the following command:
+```bash
+dotnet tool update --global DFE.SUI.Client.Watcher --add-source <url to nuget source>
+```
+```bash
+dotnet tool update --global DFE.SUI.DBS.Client.Watcher --add-source <url to nuget source>
+```
+
+## Uninstall the tools
+To uninstall the tools, you can use the following command:
+```bash
+dotnet tool uninstall --global DFE.SUI.DBS.Client.Watcher
+```
+```bash
+dotnet tool uninstall --global DFE.SUI.Client.Watcher
+```

--- a/README_Clients_User_Manual.md
+++ b/README_Clients_User_Manual.md
@@ -1,22 +1,23 @@
 # Readme for downloading and running the SUI Client Watcher tools from NuGet source
 
 ## Prerequisites
-- .NET9 SDK installed on the machine running this application.
+- .NET9 SDK installed on the machine running this application. This may require administrative permission.
 - Access to a terminal or command prompt.
 
 ## Downloading from Nuget source
 
-To use these tools, you can install it from a NuGet source using the following command:
+To use these tools, you can install it from a NuGet source with or without a specific version using the following command:
+Add a `--version <version>` parameter to the command to install a specific version.
+
+For the Client Watcher:
+```bash
+dotnet tool install --global DFE.SUI.Client.Watcher
+```
 
 For the DBS Client Watcher:
 
 ```bash
-dotnet tool install --global DFE.SUI.DBS.Client.Watcher --add-source <url to nuget source>
-```
-
-For the Client Watcher:
-```bash
-dotnet tool install --global DFE.SUI.Client.Watcher --add-source <url to nuget source>
+dotnet tool install --global DFE.SUI.DBS.Client.Watcher
 ```
 
 ## Running the watcher tool
@@ -34,18 +35,21 @@ suidbsw <inputDirectory> <outputDirectory>
 
 ## Update the tools
 To update the tools, you can use the following command:
+Add a `--version <version>` parameter to the command to install a specific version. Without version is will install the latest version.
+
 ```bash
-dotnet tool update --global DFE.SUI.Client.Watcher --add-source <url to nuget source>
+dotnet tool update --global DFE.SUI.Client.Watcher
 ```
 ```bash
-dotnet tool update --global DFE.SUI.DBS.Client.Watcher --add-source <url to nuget source>
+dotnet tool update --global DFE.SUI.DBS.Client.Watcher
 ```
 
 ## Uninstall the tools
 To uninstall the tools, you can use the following command:
-```bash
-dotnet tool uninstall --global DFE.SUI.DBS.Client.Watcher
-```
+
 ```bash
 dotnet tool uninstall --global DFE.SUI.Client.Watcher
+```
+```bash
+dotnet tool uninstall --global DFE.SUI.DBS.Client.Watcher
 ```

--- a/SUI.Client.Console/Program.cs
+++ b/SUI.Client.Console/Program.cs
@@ -11,7 +11,8 @@ var builder = Host.CreateDefaultBuilder();
 builder.ConfigureAppSettingsJsonFile();
 builder.ConfigureServices((hostContext, services) =>
 {
-    services.AddClientCore(hostContext.Configuration);
+    var matchingUrl = hostContext.Configuration["MatchApiBaseAddress"] ?? throw new Exception("Config item 'MatchApiBaseAddress' not set");
+    services.AddClientCore(hostContext.Configuration, matchingUrl!);
 });
 
 var host = builder.Build();

--- a/SUI.Client.Core/Extensions/ServiceCollectionExtensions.cs
+++ b/SUI.Client.Core/Extensions/ServiceCollectionExtensions.cs
@@ -7,13 +7,12 @@ namespace SUI.Client.Core.Extensions;
 
 public static class ServiceCollectionExtensions
 {
-    public static IServiceCollection AddClientCore(this IServiceCollection services, IConfiguration configuration)
+    public static IServiceCollection AddClientCore(this IServiceCollection services, IConfiguration configuration, string matchApiBaseAddress)
     {
-        var apiBaseAddress = configuration["MatchApiBaseAddress"] ?? throw new Exception("Config item 'MatchApiBaseAddress' not set");
         var mapping = configuration.GetSection("CsvMapping").Get<CsvMappingConfig>() ?? new CsvMappingConfig();
 
         services.AddSingleton(mapping);
-        services.AddSingleton(x => new HttpClient() { BaseAddress = new Uri(apiBaseAddress) });
+        services.AddSingleton(x => new HttpClient() { BaseAddress = new Uri(matchApiBaseAddress) });
         services.AddSingleton<ICsvFileProcessor, CsvFileProcessor>();
         services.AddSingleton<IMatchPersonApiService, MatchPersonApiService>();
         services.AddSingleton<CsvFileWatcherService>();

--- a/SUI.Client.Core/Integration/MatchPersonApiService.cs
+++ b/SUI.Client.Core/Integration/MatchPersonApiService.cs
@@ -11,11 +11,10 @@ public interface IMatchPersonApiService
 
 public class MatchPersonApiService(HttpClient httpClient) : IMatchPersonApiService
 {
-    private readonly HttpClient _httpClient = httpClient;
 
     public async Task<PersonMatchResponse?> MatchPersonAsync(MatchPersonPayload payload)
     {
-        var response = await _httpClient.PostAsJsonAsync("/matching/api/v1/matchperson", payload);
+        var response = await httpClient.PostAsJsonAsync("/matching/api/v1/matchperson", payload);
         var dto = await response.Content.ReadFromJsonAsync<PersonMatchResponse>();
         return dto;
     }

--- a/SUI.Client.Watcher/Program.cs
+++ b/SUI.Client.Watcher/Program.cs
@@ -6,13 +6,15 @@ using SUI.Client.Core.Extensions;
 using SUI.Client.Core.Watcher;
 
 Console.Out.WriteAppName("SUI CSV File Watcher");
-Rule.Assert(args.Length == 2, "Usage: suiw <watch_directory> <output_directory>");
+Rule.Assert(args.Length == 3, "Usage: suiw <watch_directory> <output_directory> <matching_service_uri>");
+Rule.Assert(Uri.IsWellFormedUriString(args[2], UriKind.Absolute), "Invalid URL format for matching service URL.");
+var matchApiBaseAddress = args[2];
 
 var builder = Host.CreateDefaultBuilder();
 builder.ConfigureAppSettingsJsonFile();
 builder.ConfigureServices((hostContext, services) =>
 {
-    services.AddClientCore(hostContext.Configuration);
+    services.AddClientCore(hostContext.Configuration, matchApiBaseAddress);
     services.AddLogging(configure => configure.AddConsole());
     services.Configure<CsvWatcherConfig>(x => 
     {

--- a/SUI.Client.Watcher/Properties/launchSettings.json
+++ b/SUI.Client.Watcher/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "SUI.Client.Watcher": {
       "commandName": "Project",
-      "commandLineArgs": "\"C:\\temp\\sui\\incoming\" \"C:\\temp\\sui\\incoming\\processed\" "
+      "commandLineArgs": "\"C:\\temp\\sui\\incoming\" \"C:\\temp\\sui\\incoming\\processed\" http://localhost:5000"
     }
   }
 }

--- a/SUI.Client.Watcher/README.md
+++ b/SUI.Client.Watcher/README.md
@@ -1,0 +1,36 @@
+# SUI Client Watcher
+
+## Creating NuGet package
+
+https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create
+
+Run the following CLI command to create a NuGet package. For CI/CD, you can use the `dotnet pack` command in your pipeline and set a version number.:
+
+```bash
+dotnet pack --configuration Release --output ./nupkg /p:PackAsTool=true /p:Version=1.0.0 /p:ToolCommandName=suiw
+```
+
+This will create a NuGet package in the `nupkg` directory with the specified version and configuration. 
+The `/p:ToolCommandName=suiw` option sets the command name for the tool
+
+## Installing the NuGet package locally
+
+To install the NuGet package locally, you can use the following command:
+
+```bash
+dotnet tool install --global --add-source ./nupkg DFE.SUI.Client.Watcher --version 1.0.0
+```
+
+## Uninstalling the NuGet package
+To uninstall the NuGet package, you can use the following command:
+
+```bash
+dotnet tool uninstall --global DFE.SUI.Client.Watcher
+```
+
+### Running the NuGet watcher tool from the command line
+To run the tool, you can use the following command:
+
+```bash
+suiw <inputDirectory> <outputDirectory> <absoluteUrlToMatchingService>
+```

--- a/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -6,6 +6,11 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<AssemblyName>suiw</AssemblyName>
+		<Title>SUI Client Watcher</Title>
+		<Company>Department for Education</Company>
+		<PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
+		<PackageId>DFE.SUI.Client.Watcher</PackageId>
+
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -23,9 +28,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <None Update="appsettings.e2etest.json">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
+		<None Update="appsettings.e2etest.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	  <None Update="appsettings.json">
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>

--- a/SUI.DBS.Client.Watcher/README.md
+++ b/SUI.DBS.Client.Watcher/README.md
@@ -1,0 +1,36 @@
+# SUI DBS Client Watcher
+
+## Creating NuGet package
+
+https://learn.microsoft.com/en-us/dotnet/core/tools/global-tools-how-to-create
+
+Run the following CLI command to create a NuGet package:
+
+```bash
+dotnet pack --configuration Release --output ./nupkg /p:PackAsTool=true /p:Version=1.0.0 /p:ToolCommandName=suidbsw
+```
+
+This will create a NuGet package in the `nupkg` directory with the specified version and configuration.
+The `/p:ToolCommandName=suidbsw` option sets the command name for the tool
+
+## Installing the NuGet package locally
+
+To install the NuGet package locally, you can use the following command:
+
+```bash
+dotnet tool install --global --add-source ./nupkg DFE.SUI.DBS.Client.Watcher --version 1.0.0
+```
+
+## Uninstalling the NuGet package
+To uninstall the NuGet package, you can use the following command:
+
+```bash
+dotnet tool uninstall --global DFE.SUI.DBS.Client.Watcher
+```
+
+### Running the NuGet watcher tool from the command line
+To run the tool, you can use the following command:
+
+```bash
+suidbsw <inoutDirectory> <outputDirectory>
+```

--- a/SUI.DBS.Client.Watcher/SUI.DBS.Client.Watcher.csproj
+++ b/SUI.DBS.Client.Watcher/SUI.DBS.Client.Watcher.csproj
@@ -6,6 +6,10 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <AssemblyName>dbsw</AssemblyName>
+        <Title>SUI DBS Client Watcher</Title>
+        <Company>Department for Education</Company>
+        <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
+        <PackageId>DFE.SUI.DBS.Client.Watcher</PackageId>
     </PropertyGroup>
 
     <ItemGroup>

--- a/SUI.Test/Integration/CsvProcessorTests.cs
+++ b/SUI.Test/Integration/CsvProcessorTests.cs
@@ -189,10 +189,6 @@ public class CsvProcessorTests
         var servicesCollection = new ServiceCollection();
         servicesCollection.AddLogging(b => b.AddDebug().AddProvider(new TestContextLoggerProvider(TestContext)));
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["MatchApiBaseAddress"] = "http://localhost"
-            })
             .Build();
 
         servicesCollection.Configure<CsvWatcherConfig>(x =>
@@ -201,7 +197,7 @@ public class CsvProcessorTests
             x.ProcessedDirectory = _dir.ProcessedDirectoryPath;
         });
 
-        servicesCollection.AddClientCore(config);
+        servicesCollection.AddClientCore(config, "http://localhost");
         servicesCollection.AddSingleton<IMatchPersonApiService, MatchPersonServiceAdapter>(); // wires up the IMatchingService directly, without using http
 
         // core domain deps


### PR DESCRIPTION
- Updated PDS Client watcher to have a URL input arg. This is because each LA will have their own unique matching service URL. Also updated to have some build details for when it is packaged as NuGet.
- Updated DBS Client watcher to have some build details for when it is packaged as NuGet.
- Added README for developers
- Added a client user README for instructions on how to use this.

Out of scope on this PR
- Nuget feed from pipeline. This will be done in a following PR once we get the OK from DfE to publish to Nuget.org