### PR TITLE
Feat: 144 - data pds differences

### DIFF
--- a/SUI.Core/Endpoints/NhsFhirClient.cs
+++ b/SUI.Core/Endpoints/NhsFhirClient.cs
@@ -63,19 +63,14 @@ public class NhsFhirClient(ITokenService tokenService,
             }
             else
             {
+                logger.LogInformation("{EntryCount} patient record(s) found", patient.Entry.Count);
                 if (patient.Entry.Count == 0)
                 {
-                    logger.LogInformation("No patient record found");
-
                     return SearchResult.Unmatched();
                 }
 
                 if (patient.Entry.Count == 1)
                 {
-                    var birthDate = patient.Entry[0].Resource["birthDate"].ToString();
-                    var gender = patient.Entry[0].Resource["gender"].ToString();
-
-                    logger.LogInformation("1 patient record found: BirthDate={BirthDate} Gender={Gender}", birthDate, gender);
                     LogInputAndPdsDifferences(query, (Patient)patient.Entry[0].Resource);
 
                     return SearchResult.Match(patient.Entry[0].Resource.Id, patient.Entry[0].Search.Score);

--- a/SUI.Core/Services/FieldComparerService.cs
+++ b/SUI.Core/Services/FieldComparerService.cs
@@ -1,0 +1,43 @@
+using Hl7.Fhir.Model;
+using Shared.Models;
+
+namespace SUI.Core.Services;
+
+public static class FieldComparerService
+{
+    /// <summary>
+    /// Compares the fields of the SearchQuery and the Patient object.
+    /// </summary>
+    /// <param name="query">Search query</param>
+    /// <param name="patient">Fhir Patient</param>
+    /// <returns>The names of the fields that have different values between query and patient</returns>
+    public static List<string> ComparePatientFields(SearchQuery query, Patient patient)
+    {
+        var differentFields = new List<string>();
+
+        CompareField(query.Birthdate?.FirstOrDefault(), $"eq{patient.BirthDate}", nameof(SearchQuery.Birthdate), differentFields);
+        CompareField(query.AddressPostalcode, patient.Address.FirstOrDefault()?.PostalCode, nameof(SearchQuery.AddressPostalcode), differentFields);
+        CompareField(query.Gender, patient.Gender?.ToString(), nameof(SearchQuery.Gender), differentFields);
+        CompareField(query.Family, patient.Name.FirstOrDefault()?.Family, nameof(SearchQuery.Family), differentFields);
+        CompareField(query.Given?.FirstOrDefault(), patient.Name.FirstOrDefault()?.Given.FirstOrDefault(), nameof(SearchQuery.Given), differentFields);
+
+        var email = patient.Telecom.FirstOrDefault(x => x.System == ContactPoint.ContactPointSystem.Email)?.Value;
+        CompareField(query.Email, email, nameof(SearchQuery.Email), differentFields);
+        
+        var phone = patient.Telecom.FirstOrDefault(x => x.System == ContactPoint.ContactPointSystem.Phone)?.Value;
+        CompareField(query.Phone, phone, nameof(SearchQuery.Phone), differentFields);
+
+        return differentFields;
+    }
+
+    private static void CompareField(string? queryValue, string? resourceValue, string fieldName, List<string> differentFields)
+    {
+        // Assumption that we don't compare if our input is null
+        if (queryValue is null) return;
+
+        if (!queryValue.Equals(resourceValue, StringComparison.OrdinalIgnoreCase))
+        {
+            differentFields.Add(fieldName);
+        }
+    }
+}

--- a/SUI.Core/Services/MatchingService.cs
+++ b/SUI.Core/Services/MatchingService.cs
@@ -272,7 +272,7 @@ public class MatchingService(
 
         var hash = builder.ToString();
 
-        Activity.Current?.SetTag("SearchId", hash);
+        Activity.Current?.SetBaggage("SearchId", hash);
     }
 
     private SearchQuery[] GetSearchQueries(PersonSpecification model)

--- a/SUI.DBS.Client.Core/TextFileProcessor.cs
+++ b/SUI.DBS.Client.Core/TextFileProcessor.cs
@@ -102,7 +102,7 @@ public class TxtFileProcessor(ILogger<TxtFileProcessor> logger) : ITxtFileProces
 
         var hash = builder.ToString();
 
-        Activity.Current?.SetTag("SearchId", hash);
+        Activity.Current?.SetBaggage("SearchId", hash);
     }
 
     

--- a/SUI.Test/Unit/Core/Services/FieldComparerServiceTests.cs
+++ b/SUI.Test/Unit/Core/Services/FieldComparerServiceTests.cs
@@ -1,0 +1,71 @@
+using Hl7.Fhir.Model;
+using Shared.Models;
+using SUI.Core.Services;
+
+namespace SUI.Test.Unit.Core.Services;
+
+[TestClass]
+public class FieldComparerServiceTests
+{
+    [TestMethod]
+    public void ComparePatientFields_ShouldReturnDifferences_WhenFieldsDoNotMatch()
+    {
+        // Arrange
+        var query = new SearchQuery
+        {
+            Birthdate = ["eq1990-01-01"],
+            AddressPostalcode = "12345",
+            Phone = "555-1234",
+            Gender = "male",
+            Family = "Smith",
+            Given = ["John"],
+            Email = "john.doe@example.com"
+        };
+
+        var patient = new Patient
+        {
+            BirthDate = "1980-01-01",
+            Address = [new Address { PostalCode = "54321" }],
+            Telecom =
+            [
+                new ContactPoint { Value = "555-5678", System = ContactPoint.ContactPointSystem.Phone },
+                new ContactPoint { Value = "john.doe@example.com", System = ContactPoint.ContactPointSystem.Email }
+            ],
+            Gender = AdministrativeGender.Female,
+            Name = [new HumanName { Family = "Smith", Given = ["Jane"] }]
+        };
+
+        // Act
+        var differences = FieldComparerService.ComparePatientFields(query, patient);
+
+        // Assert
+        CollectionAssert.Contains(differences, nameof(SearchQuery.Birthdate));
+        CollectionAssert.Contains(differences, nameof(SearchQuery.AddressPostalcode));
+        CollectionAssert.Contains(differences, nameof(SearchQuery.Phone));
+        CollectionAssert.Contains(differences, nameof(SearchQuery.Gender));
+        CollectionAssert.Contains(differences, nameof(SearchQuery.Given));
+        CollectionAssert.DoesNotContain(differences, nameof(SearchQuery.Family));
+        CollectionAssert.DoesNotContain(differences, nameof(SearchQuery.Email));
+    }
+    
+    [TestMethod]
+    public void ShouldIdentifyBirthdateAsTheSame()
+    {
+        // Arrange
+        var query = new SearchQuery
+        {
+            Birthdate = ["eq1980-01-01"]
+        };
+
+        var patient = new Patient
+        {
+            BirthDate = "1980-01-01"
+        };
+
+        // Act
+        var differences = FieldComparerService.ComparePatientFields(query, patient);
+
+        // Assert
+        Assert.IsFalse(differences.Contains(nameof(SearchQuery.Birthdate)));
+    }
+}

--- a/shared/Shared/Attributes/CheckEmptyAttribute.cs
+++ b/shared/Shared/Attributes/CheckEmptyAttribute.cs
@@ -1,0 +1,9 @@
+namespace Shared.Attributes;
+
+/// <summary>
+/// Simple attribute used to mark properties that should be checked for empty values.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property)]
+public class CheckEmptyAttribute : Attribute
+{
+}

--- a/shared/Shared/Logging/ApplicationEnricher.cs
+++ b/shared/Shared/Logging/ApplicationEnricher.cs
@@ -11,7 +11,7 @@ public class ApplicationEnricher(IHttpContextAccessor httpContextAccessor) : ILo
 {
 	public void Enrich(IEnrichmentTagCollector collector)
 	{
-		if (Activity.Current?.GetTagItem("SearchId") is { } searchId)
+		if (Activity.Current?.GetBaggageItem("SearchId") is { } searchId)
 		{
 			collector.Add("SearchId", searchId);
 		}

--- a/shared/Shared/Logging/LogConsoleFormatter.cs
+++ b/shared/Shared/Logging/LogConsoleFormatter.cs
@@ -25,7 +25,7 @@ public class LogConsoleFormatter : ConsoleFormatter
             return;
         }
 
-        var searchId = Activity.Current?.GetTagItem("SearchId");
+        var searchId = Activity.Current?.GetBaggageItem("SearchId");
 
         if (searchId is not null)
         {

--- a/shared/Shared/Models/SearchQuery.cs
+++ b/shared/Shared/Models/SearchQuery.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Reflection;
+using Shared.Attributes;
 
 namespace Shared.Models;
 
@@ -19,39 +20,71 @@ public sealed class SearchQuery
 	[JsonPropertyName("_max-results")]
 	public bool? MaxResults { get; set; }
 
+	[CheckEmpty]
 	[RegularExpression(DateQueryRegex, ErrorMessage = "Incorrect format.")]
 	[JsonPropertyName("death-date")]
 	public string[]? DeathDate { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("address-postalcode")]
 	public string? AddressPostalcode { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("address-postcode")]
 	public string? AddressPostcode { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("general-practitioner")]
 	public string? GeneralPractitioner { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("family")]
 	public string? Family { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("given")]
 	public string[]? Given { get; set; }
 	
+	[CheckEmpty]
 	[RegularExpression("male||female||other||unknown", ErrorMessage = "Incorrect format.")]
 	[JsonPropertyName("gender")]
 	public string? Gender { get; set; }
 	
+	[CheckEmpty]
 	[EmailAddress]
 	[JsonPropertyName("email")]
 	public string? Email { get; set; }
 	
+	[CheckEmpty]
 	[JsonPropertyName("phone")]
 	public string? Phone { get; set; }
 	
+	[CheckEmpty]
 	[RegularExpression(DateQueryRegex, ErrorMessage = "Incorrect format.")]
 	[JsonPropertyName("birthdate")]
 	public string[]? Birthdate { get; set; }
+
+	public string[] EmptyFields()
+	{
+		var emptyFields = new List<string>();
+
+		var properties = GetType().GetProperties();
+
+		foreach (var property in properties)
+		{
+			if (property.GetCustomAttribute<CheckEmptyAttribute>() == null) continue;
+			
+			var value = property.GetValue(this);
+
+			if (value == null || (value is string str && string.IsNullOrEmpty(str)) ||
+			    value is Array { Length: 0 })
+			{
+				emptyFields.Add(property.Name);
+			}
+		}
+
+		return emptyFields.ToArray();
+	}
 	
 	public Dictionary<string, object> ToDictionary()
 	{
@@ -83,5 +116,5 @@ public sealed class SearchQuery
 		male,
 		other,
 		unknown
-	} 
+	}
 }

--- a/shared/Shared/Models/SearchQuery.cs
+++ b/shared/Shared/Models/SearchQuery.cs
@@ -19,23 +19,10 @@ public sealed class SearchQuery
 	
 	[JsonPropertyName("_max-results")]
 	public bool? MaxResults { get; set; }
-
-	[CheckEmpty]
-	[RegularExpression(DateQueryRegex, ErrorMessage = "Incorrect format.")]
-	[JsonPropertyName("death-date")]
-	public string[]? DeathDate { get; set; }
 	
 	[CheckEmpty]
 	[JsonPropertyName("address-postalcode")]
 	public string? AddressPostalcode { get; set; }
-	
-	[CheckEmpty]
-	[JsonPropertyName("address-postcode")]
-	public string? AddressPostcode { get; set; }
-	
-	[CheckEmpty]
-	[JsonPropertyName("general-practitioner")]
-	public string? GeneralPractitioner { get; set; }
 	
 	[CheckEmpty]
 	[JsonPropertyName("family")]


### PR DESCRIPTION
- Updated the Get and Set Activity Tag to be 'Baggage' instead as this carries data accross HTTP requests via headers. This change was made so we can have the SearchId persist to the External service.
- Added a Comparison class and unit tested some scenarios
- Added logging to the FhirService as this is the closest place to the request data.

I believe I've captured all required fields but please double check when reviewing this PR.
