### PR TITLE
SUI-153 Added default input values for auto run Github workflows as they can't access the defaults in `workflow_dispatch.inputs.variable.default`

### DIFF
--- a/.github/workflows/gh-client-build.yml
+++ b/.github/workflows/gh-client-build.yml
@@ -4,8 +4,8 @@ on:
     workflow_dispatch:
         inputs:
             version:
-                description: 'Version number'
-                required: true
+                description: 'Version number (if empty the latest version is use)'
+                required: false
                 default: 'v0.0.45'
             blob_storage_location:
                 description: 'Blob storage location'
@@ -32,20 +32,38 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env: 
-            AZURE_ENV_NAME: ${{ inputs.environment }}
+            AZURE_ENV_NAME: ${{ inputs.environment || 'Integration' }}
             AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
             AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
             AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             AZURE_LOCATION: "westeurope"
             AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-            CLIENT_VERSION: ${{ inputs.version }}
-            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location }}
-            STORAGE_ACCOUNT: ${{ inputs.storage_account }}
-            VN_NAME: ${{ inputs.virtual_machine_name }}
+            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location || 's215d01-integration-container-01' }}
+            STORAGE_ACCOUNT: ${{ inputs.storage_account || 's215d01integrationsa01' }}
+            VN_NAME: ${{ inputs.virtual_machine_name || 's215d01-integration-vm-01' }}
 
         steps:
         - name: Checkout repository
           uses: actions/checkout@v4
+
+        - name: Use version inputted or find latest tag
+          id: check-version
+          run: |
+            if [ -z "${{ github.event.inputs.version }}" ]; then
+              echo "No input version provided. Fetching latest tag."
+              git fetch --tags
+              latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+              echo "Latest tag: $latest_tag"
+              echo "CLIENT_VERSION=$latest_tag" >> $GITHUB_ENV
+            else
+              echo "Using input version: ${{ github.event.inputs.version }}"
+              echo "CLIENT_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            fi
+            
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with: 
+            ref: ${{ env.CLIENT_VERSION }}
 
         - name: Setup .NET
           uses: actions/setup-dotnet@v4

--- a/.github/workflows/gh-dbs-client-build.yml
+++ b/.github/workflows/gh-dbs-client-build.yml
@@ -1,11 +1,11 @@
-name: Build and Upload DBS Client Watcher
+name: Build and Upload DBS Response Logger Watcher
 
 on:
     workflow_dispatch:
         inputs:
             version:
-                description: 'Version number'
-                required: true
+                description: 'Version number (if empty the latest version is use)'
+                required: false
                 default: 'v0.0.45'
             blob_storage_location:
                 description: 'Blob storage location'
@@ -32,30 +32,48 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env: 
-            AZURE_ENV_NAME: ${{ inputs.environment }}
+            AZURE_ENV_NAME: ${{ inputs.environment || 'Integration' }}
             AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
             AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
             AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             AZURE_LOCATION: "westeurope"
             AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-            CLIENT_VERSION: ${{ inputs.version }}
-            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location }}
-            STORAGE_ACCOUNT: ${{ inputs.storage_account }}
-            VN_NAME: ${{ inputs.virtual_machine_name }}
+            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location || 's215d01-integration-container-01' }}
+            STORAGE_ACCOUNT: ${{ inputs.storage_account || 's215d01integrationsa01' }}
+            VN_NAME: ${{ inputs.virtual_machine_name || 's215d01-integration-vm-01' }}
 
         steps:
         - name: Checkout repository
           uses: actions/checkout@v4
+
+        - name: Use version inputted or find latest tag
+          id: check-version
+          run: |
+            if [ -z "${{ github.event.inputs.version }}" ]; then
+              echo "No input version provided. Fetching latest tag."
+              git fetch --tags
+              latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+              echo "Latest tag: $latest_tag"
+              echo "CLIENT_VERSION=$latest_tag" >> $GITHUB_ENV
+            else
+              echo "Using input version: ${{ github.event.inputs.version }}"
+              echo "CLIENT_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            fi
+
+        - name: Checkout repository
+          uses: actions/checkout@v4
+          with:
+            ref: ${{ env.CLIENT_VERSION }}
 
         - name: Setup .NET
           uses: actions/setup-dotnet@v4
           with:
             dotnet-version: '9.0.x'
 
-        - name: Publish DBS Client Watcher
+        - name: Publish DBS Response Logger Watcher
           run: dotnet publish SUI.DBS.Client.Watcher -r win-x64 --self-contained /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --configuration Release --output ./output --version-suffix ${{ env.CLIENT_VERSION }}
 
-        - name: Publish DBS Client Console
+        - name: Publish DBS Response Logger Console
           run: dotnet publish SUI.DBS.Client.Console -r win-x64 --self-contained /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true --configuration Release --output ./output --version-suffix ${{ env.CLIENT_VERSION }}
 
         - name: Login to Azure
@@ -91,5 +109,5 @@ jobs:
               # Download DBS EXE files from Blob Storage
               az storage blob download-batch --connection-string $connectionString --destination $destinationDir --source $blobContainerName --pattern "dbs*.exe" --overwrite true
 
-              Write-Host "DBS client EXE files downloaded"
+              Write-Host "DBS Response Logger EXE files downloaded"
             '

--- a/.github/workflows/gh-deploy-app.yml
+++ b/.github/workflows/gh-deploy-app.yml
@@ -13,7 +13,7 @@ on:
         options:
           - 'Integration'
       version:
-        description: The version of the infrastructure to deploy
+        description: The version of the infrastructure to deploy (if empty the latest version is use)
         type: string
         required: false
 
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env: 
-      AZURE_ENV_NAME: ${{ inputs.environment }}
+      AZURE_ENV_NAME: ${{ inputs.environment || 'Integration' }}
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         
-      - name: Check if input version is empty
+      - name: Use version inputted or find latest tag
         id: check-version
         run: |
           if [ -z "${{ github.event.inputs.version }}" ]; then

--- a/.github/workflows/gh-smoke-test.yml
+++ b/.github/workflows/gh-smoke-test.yml
@@ -19,8 +19,18 @@ on:
          description: 'Environment'
          required: true
          default: 'Integration'
+       after_workflow:
+         description: 'Trigger specific smoke test workflow'
+         type: choice
+         required: true
+         default: 'Azure App Deployment'
+         options:
+           - "Azure App Deployment"
+           - "Build and Upload Client Watcher"
+           - "Build and Upload DBS Response Logger Watcher"
+         
   workflow_run:
-    workflows: ["Azure App Deployment", "Build and Upload Client Watcher", "Build and Upload DBS Client Watcher"]
+    workflows: ["Azure App Deployment", "Build and Upload Client Watcher", "Build and Upload DBS Response Logger Watcher"]
     types:
       - completed
   schedule:
@@ -34,19 +44,35 @@ jobs:
     build:
         runs-on: ubuntu-latest
         env: 
-            AZURE_ENV_NAME: ${{ inputs.environment }}
+            AZURE_ENV_NAME: ${{ inputs.environment || 'Integration' }}
             AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
             AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
             AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
             AZURE_LOCATION: "westeurope"
             AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
-            CLIENT_VERSION: ${{ inputs.version }}
-            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location }}
-            STORAGE_ACCOUNT: ${{ inputs.storage_account }}
+            BLOB_STORAGE_LOCATION: ${{ inputs.blob_storage_location || 's215d01-integration-container-01' }}
+            STORAGE_ACCOUNT: ${{ inputs.storage_account || 's215d01integrationsa01' }}
 
         steps:
-        - name: Checkout code
-          uses: actions/checkout@v3
+        - name: Checkout
+          uses: actions/checkout@v4
+
+        - name: Use version inputted or find latest tag
+          id: check-version
+          run: |
+            if [ -z "${{ github.event.inputs.version }}" ]; then
+              echo "No input version provided. Fetching latest tag."
+              git fetch --tags
+              latest_tag=$(git describe --tags `git rev-list --tags --max-count=1`)
+              echo "Latest tag: $latest_tag"
+              echo "CLIENT_VERSION=$latest_tag" >> $GITHUB_ENV
+            else
+              echo "Using input version: ${{ github.event.inputs.version }}"
+              echo "CLIENT_VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+            fi
+
+        - name: Checkout
+          uses: actions/checkout@v4
           with:
             ref: ${{ env.CLIENT_VERSION }}
 
@@ -68,7 +94,14 @@ jobs:
 
         - name: Determine triggering upstream workflow
           id: detect_workflow
-          run: echo "triggered_workflow=${{ github.event.workflow }}" >> $GITHUB_ENV
+          run: |
+            if [ -z "${{ github.event.inputs.after_workflow }}" ]; then
+              echo "triggered_workflow=${{ github.event.inputs.after_workflow }}" >> $GITHUB_ENV
+            elif [ "${{ github.event_name == 'schedule' }}" == "true" ]; then
+              echo "cron_run='true'" >> $GITHUB_ENV
+            else
+              echo "triggered_workflow=${{ github.event.workflow || 'Azure App Deployment' }}" >> $GITHUB_ENV
+            fi
 
         - name: Upload TXT Files to Blob Storage
           run:
@@ -78,8 +111,8 @@ jobs:
           run:
             az storage blob upload-batch --destination ${{ env.BLOB_STORAGE_LOCATION }} --account-name ${{ env.STORAGE_ACCOUNT }} --source ./SUI.Test/Smoke --pattern "*.csv" --overwrite
             
-        - name: Smoke Test DBS Client (.exe)
-          if: env.triggered_workflow == 'Build and Upload Client Watcher'
+        - name: Smoke Test DBS Response Logger (.exe)
+          if: ((env.triggered_workflow == 'Build and Upload DBS Response Logger Watcher') || (env.cron_run == 'true'))
           run: |
             az vm run-command invoke \
               --command-id RunPowerShellScript \
@@ -121,7 +154,7 @@ jobs:
               '
             
         - name: Smoke Test SUI Client (.exe)
-          if: env.triggered_workflow == 'Azure App Deployment' || env.triggered_workflow == 'Build and Upload DBS Client Watcher'
+          if: ((env.triggered_workflow == 'Azure App Deployment' || env.triggered_workflow == 'Build and Upload Client Watcher') || (env.cron_run == 'true'))
           run: |
             az vm run-command invoke \
               --command-id RunPowerShellScript \

--- a/SUI.Client.Watcher/infra/client.bicep
+++ b/SUI.Client.Watcher/infra/client.bicep
@@ -119,7 +119,7 @@ resource vm 'Microsoft.Compute/virtualMachines@2022-03-01' = {
   }
 }
 
-resource virtualMachines_s215d01_integration_vm_01_name_Microsoft_Insights_VMDiagnosticsSettings 'Microsoft.Compute/virtualMachines/extensions@2024-07-01' = {
+resource vm_diagnostics_settings 'Microsoft.Compute/virtualMachines/extensions@2024-07-01' = {
   parent: vm
   name: 'Microsoft.Insights.VMDiagnosticsSettings'
   location: 'westeurope'


### PR DESCRIPTION
- this fixes errors such as `ERROR: loading environment: reading environment name: no default response for prompt 'Enter a new environment name:'`

<img width="747" alt="image" src="https://github.com/user-attachments/assets/b8d317d0-01f8-4822-9d8b-9a3b96f2248d" />

source: https://stackoverflow.com/questions/73404033/how-to-keep-default-action-input-if-parameter-passed-is-empty-in-github-action

- Changed `DBS Client` references to `DBS Response Logger`
- Added defaults and cron_run condition to smoke test github workflow