### PR TITLE
Feat - 71 - github publish nuget workflow

### DIFF
--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -101,7 +101,8 @@ jobs:
           dotnet pack ./src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.CLIENT_VERSION }}
+            /p:Version=${{ env.CLIENT_VERSION }} \
+            /p:PackAsTool=true
 
       - name: Publish Client Watcher
         if: ${{ github.event.inputs.publish-client == 'true' }}
@@ -116,7 +117,8 @@ jobs:
           dotnet pack ./src/tools/DbsResponseLogger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.DBS_VERSION }}
+            /p:Version=${{ env.DBS_VERSION }} \
+            /p:PackAsTool=true
           
       - name: Publish Response Logger
         if: ${{ github.event.inputs.publish-response-logger == 'true' }}

--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Package Response Logger
         if: ${{ github.event.inputs.publish-response-logger == 'true' }}
         run: |
-          dotnet pack ./src/tools/DbsResponseLogger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
+          dotnet pack ./src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
             /p:Version=${{ env.DBS_VERSION }} \

--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -14,8 +14,8 @@ on:
         type: boolean
         
 env: 
-  client_name: 'DFE.SUI.Client.Watcher'
-  response_logger_name: 'DFE.SUI.DBS.Response.Logger.Watcher'
+  client_name: 'SUI.Client.Watcher'
+  response_logger_name: 'SUI.DBS.Response.Logger.Watcher'
 
 jobs:
   publish:
@@ -23,18 +23,92 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+        
+      - name: 'TEST - nuget version'
+        id: test_version
+        run: |
+          TEST_PACKAGE_NAME="Newtonsoft.Json"
+          API_URL="https://api.nuget.org/v3-flatcontainer/${TEST_PACKAGE_NAME,,}/index.json"
+          RESPONSE=$(curl -s -w "%{http_code}" -o response_test.json "$API_URL")
+          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
+          
+          echo "URL=$API_URL"
+          echo "HTTP_STATUS=$HTTP_STATUS"
 
+          if [[ "$HTTP_STATUS" == "404" ]]; then
+            echo "Version not found, setting to 0.0.1"
+            VERSION="0.0.1"
+          else
+            echo "Version found, incrementing patch version"
+            LAST_VERSION=$(jq -r '.versions[-1]' response_test.json)
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+            PATCH=$((PATCH + 1))
+            VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+
+          echo "NEWTON_VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: 'Get Client Nuget version'
+        id: current_nuget_client_version
+        run: |
+          LOWERCASE_NAME="${{ env.client_name }}"
+          LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
+          API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
+          RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
+          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
+          
+          echo "URL=$API_URL"
+          echo "HTTP_STATUS=$HTTP_STATUS"
+          
+          if [[ "$HTTP_STATUS" == "404" ]]; then
+            VERSION="0.0.1"
+          else
+            LAST_VERSION=$(jq -r '.versions[-1]' response.json)
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+            PATCH=$((PATCH + 1))
+            VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+
+          echo "CLIENT_VERSION=$VERSION" >> $GITHUB_ENV
+          
+      - name: 'Get Dbs logger nuget version'
+        id: current_nuget_dbs_version
+        run: |
+          LOWERCASE_NAME="${{ env.response_logger_name }}"
+          LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
+          API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
+          RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
+          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
+          
+          echo "URL=$API_URL"
+          echo "HTTP_STATUS=$HTTP_STATUS"
+          
+          if [[ "$HTTP_STATUS" == "404" ]]; then
+            VERSION="0.0.1"
+          else
+            LAST_VERSION=$(jq -r '.versions[-1]' response.json)
+            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+            PATCH=$((PATCH + 1))
+            VERSION="$MAJOR.$MINOR.$PATCH"
+          fi
+
+          echo "DBS_VERSION=$VERSION" >> $GITHUB_ENV
+      
+      - name: Print Package Version
+        run: |
+          echo "next client nuget version: ${{ env.CLIENT_VERSION }}"
+          echo "next dbs nuget version: ${{ env.DBS_VERSION }}"
+          echo "test nuget version: ${{ env.NEWTON_VERSION }}"
+          
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-
-      - name: Fetch latest GitHub tag
-        id: fetch-latest-tag
-        run: |
-          latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))
-          echo "Latest tag: $latest_tag"
-          echo "LATEST_VERSION=latest_tag" >> $GITHUB_ENV
 
       - name: Package Client Watcher
         if: ${{ github.event.inputs.publish-client == 'true' }}
@@ -42,7 +116,7 @@ jobs:
           dotnet pack ./src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.LATEST_VERSION }}
+            /p:Version=${{ env.PACKAGE_VERSION }}
 
       - name: Publish Client Watcher
         if: ${{ github.event.inputs.publish-client == 'true' }}
@@ -57,7 +131,7 @@ jobs:
           dotnet pack ./src/tools/DbsResponseLogger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.LATEST_VERSION }}
+            /p:Version=${{ env.PACKAGE_VERSION }}
           
       - name: Publish Response Logger
         if: ${{ github.event.inputs.publish-response-logger == 'true' }}

--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -101,12 +101,12 @@ jobs:
           dotnet pack ./src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.PACKAGE_VERSION }}
+            /p:Version=${{ env.CLIENT_VERSION }}
 
       - name: Publish Client Watcher
         if: ${{ github.event.inputs.publish-client == 'true' }}
         run: |
-          dotnet nuget push ./nukpg/${{env.client_name}}.${{ env.PACKAGE_VERSION }}.nupkg \
+          dotnet nuget push ./nukpg/${{env.client_name}}.${{ env.CLIENT_VERSION }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
           
@@ -116,12 +116,12 @@ jobs:
           dotnet pack ./src/tools/DbsResponseLogger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
             --configuration Release \
             --output ./nukpg \
-            /p:Version=${{ env.PACKAGE_VERSION }}
+            /p:Version=${{ env.DBS_VERSION }}
           
       - name: Publish Response Logger
         if: ${{ github.event.inputs.publish-response-logger == 'true' }}
         run: |
-          dotnet nuget push ./nukpg/${{env.response_logger_name}}.${{ env.PACKAGE_VERSION }}.nupkg \
+          dotnet nuget push ./nukpg/${{env.response_logger_name}}.${{ env.DBS_VERSION }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
       

--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -7,11 +7,19 @@ on:
         required: true
         default: false
         type: boolean
+      version-client:
+        description: 'Version of the client watcher to publish (if none select, auto increment patch version)'
+        required: false
+        type: string
       publish-response-logger:
         description: 'Publish the response logger to NuGet (Uses github latest tag)'
         required: true
         default: false
         type: boolean
+      version-response-logger:
+        description: 'Version of the response logger to publish (if none select, auto increment patch version)'
+        required: false
+        type: string
         
 env: 
   client_name: 'SUI.Client.Watcher'
@@ -28,50 +36,27 @@ jobs:
           
       - name: Install jq
         run: sudo apt-get update && sudo apt-get install -y jq
-        
-      - name: 'TEST - nuget version'
-        id: test_version
-        run: |
-          TEST_PACKAGE_NAME="Newtonsoft.Json"
-          API_URL="https://api.nuget.org/v3-flatcontainer/${TEST_PACKAGE_NAME,,}/index.json"
-          RESPONSE=$(curl -s -w "%{http_code}" -o response_test.json "$API_URL")
-          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
-          
-          echo "URL=$API_URL"
-          echo "HTTP_STATUS=$HTTP_STATUS"
-
-          if [[ "$HTTP_STATUS" == "404" ]]; then
-            echo "Version not found, setting to 0.0.1"
-            VERSION="0.0.1"
-          else
-            echo "Version found, incrementing patch version"
-            LAST_VERSION=$(jq -r '.versions[-1]' response_test.json)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
-            PATCH=$((PATCH + 1))
-            VERSION="$MAJOR.$MINOR.$PATCH"
-          fi
-
-          echo "NEWTON_VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: 'Get Client Nuget version'
         id: current_nuget_client_version
         run: |
-          LOWERCASE_NAME="${{ env.client_name }}"
-          LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
-          API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
-          RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
-          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
-          
-          echo "URL=$API_URL"
-          echo "HTTP_STATUS=$HTTP_STATUS"
-          
-          if [[ "$HTTP_STATUS" == "404" ]]; then
-            VERSION="0.0.1"
+          if [[ -n "${{ github.event.inputs.version-client }}" ]]; then
+           VERSION="${{ github.event.inputs.version-client }}"
           else
-            LAST_VERSION=$(jq -r '.versions[-1]' response.json)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
-            PATCH=$((PATCH + 1))
-            VERSION="$MAJOR.$MINOR.$PATCH"
+           LOWERCASE_NAME="${{ env.client_name }}"
+           LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
+           API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
+           RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
+           HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
+          
+           if [[ "$HTTP_STATUS" == "404" ]]; then
+             VERSION="0.0.1"
+           else
+             LAST_VERSION=$(jq -r '.versions[-1]' response.json)
+             IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+             PATCH=$((PATCH + 1))
+             VERSION="$MAJOR.$MINOR.$PATCH"
+           fi
           fi
 
           echo "CLIENT_VERSION=$VERSION" >> $GITHUB_ENV
@@ -79,22 +64,23 @@ jobs:
       - name: 'Get Dbs logger nuget version'
         id: current_nuget_dbs_version
         run: |
-          LOWERCASE_NAME="${{ env.response_logger_name }}"
-          LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
-          API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
-          RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
-          HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
-          
-          echo "URL=$API_URL"
-          echo "HTTP_STATUS=$HTTP_STATUS"
-          
-          if [[ "$HTTP_STATUS" == "404" ]]; then
-            VERSION="0.0.1"
+          if [[ -n "${{ github.event.inputs.version-response-logger }}" ]]; then
+           VERSION="${{ github.event.inputs.version-response-logger }}"
           else
-            LAST_VERSION=$(jq -r '.versions[-1]' response.json)
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
-            PATCH=$((PATCH + 1))
-            VERSION="$MAJOR.$MINOR.$PATCH"
+           LOWERCASE_NAME="${{ env.response_logger_name }}"
+           LOWERCASE_NAME=$(echo "$LOWERCASE_NAME" | tr '[:upper:]' '[:lower:]')
+           API_URL="https://api.nuget.org/v3-flatcontainer/${LOWERCASE_NAME}/index.json"
+           RESPONSE=$(curl -s -w "%{http_code}" -o response.json "$API_URL")
+           HTTP_STATUS=$(tail -n1 <<< "$RESPONSE")
+          
+           if [[ "$HTTP_STATUS" == "404" ]]; then
+             VERSION="0.0.1"
+           else
+             LAST_VERSION=$(jq -r '.versions[-1]' response.json)
+             IFS='.' read -r MAJOR MINOR PATCH <<< "$LAST_VERSION"
+             PATCH=$((PATCH + 1))
+             VERSION="$MAJOR.$MINOR.$PATCH"
+           fi
           fi
 
           echo "DBS_VERSION=$VERSION" >> $GITHUB_ENV
@@ -103,7 +89,6 @@ jobs:
         run: |
           echo "next client nuget version: ${{ env.CLIENT_VERSION }}"
           echo "next dbs nuget version: ${{ env.DBS_VERSION }}"
-          echo "test nuget version: ${{ env.NEWTON_VERSION }}"
           
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/src/tools/client/SUI.Client.Watcher/README.md
+++ b/src/tools/client/SUI.Client.Watcher/README.md
@@ -1,20 +1,5 @@
 # SUI Client Watcher
 
-## Installing the NuGet package
-
-To install the NuGet package, you can use the following command:
-
-```bash
-dotnet tool install --global DFE.SUI.Client.Watcher
-```
-
-## Uninstalling the NuGet package
-To uninstall the NuGet package, you can use the following command:
-
-```bash
-dotnet tool uninstall --global DFE.SUI.Client.Watcher
-```
-
 ### Running the NuGet watcher tool from the command line
 To run the tool, you can use the following command:
 

--- a/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -9,7 +9,7 @@
         <Title>SUI Client Watcher</Title>
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
-        <PackageId>DFE.SUI.Client.Watcher</PackageId>
+        <PackageId>SUI.Client.Watcher</PackageId>
 
     </PropertyGroup>
 

--- a/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -10,6 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.Client.Watcher</PackageId>
+        <ToolCommandName>suiw</ToolCommandName>
 
     </PropertyGroup>
 

--- a/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -11,6 +11,7 @@
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.Client.Watcher</PackageId>
         <ToolCommandName>suiw</ToolCommandName>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
 
     </PropertyGroup>
 
@@ -35,7 +36,7 @@
         <None Update="appsettings.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
-        <None Include="README.md" Pack="true"/>
+        <None Include="README.md" Pack="true" PackagePath="\"/>
     </ItemGroup>
 
 </Project>

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/README.md
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/README.md
@@ -1,19 +1,4 @@
-# SUI DBS Client Watcher
-
-## Installing the NuGet package
-
-To install the NuGet package, you can use the following command:
-
-```bash
-dotnet tool install --global DFE.SUI.DBS.Response.Logger.Watcher
-```
-
-## Uninstalling the NuGet package
-To uninstall the NuGet package, you can use the following command:
-
-```bash
-dotnet tool uninstall --global DFE.SUI.DBS.Response.Logger.Watcher
-```
+# SUI DBS Response Logger Watcher
 
 ### Running the NuGet watcher tool from the command line
 To run the tool, you can use the following command:

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -9,7 +9,7 @@
         <Title>SUI DBS Response Logger Watcher</Title>
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
-        <PackageId>DFE.SUI.DBS.Response.Logger.Watcher</PackageId>
+        <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -10,6 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
+        <ToolCommandName>suidbsw</ToolCommandName>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -11,6 +11,7 @@
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
         <ToolCommandName>suidbsw</ToolCommandName>
+        <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -34,7 +35,7 @@
         <None Update="appsettings.json">
             <CopyToOutputDirectory>Always</CopyToOutputDirectory>
         </None>
-        <None Include="README.md" Pack="true"/>
+        <None Include="README.md" Pack="true"  PackagePath="\"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated to use existing nuget versions to auto update if the user does not specify. I believe this is ok for now until we improve on the automation.
- Updated the package .csproj and workflow to pack as tool and have tool command names
- Updated READMEs for both watchers to be available on nuget.org

This is just an initial way to do it so we can get running. We can iterate on this later.

Check workflow actions to see that both packages are deploying to nuget