### PR TITLE
feat: sui-429

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,8 +4,8 @@ env:
 
 on:
   push:
-    branches:
-      - main
+    paths:
+      - 'documentation/**'
 
 jobs:
   publish:

--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -1,5 +1,11 @@
 name: Publish client NuGet packages
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/tools/client/SUI.Client.Watcher/**'
+      - 'src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/**'
   workflow_dispatch:
     inputs:
       publish-client:
@@ -95,8 +101,28 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
+      - name: Check changed files to set publish flags
+        id: check-changed-files
+        run: |
+          if git diff --name-only HEAD^ | grep -q 'src/tools/client'; then
+            echo "publish-client=true" >> $GITHUB_ENV
+          else
+            echo "publish-client=false" >> $GITHUB_ENV
+          fi
+
+          if git diff --name-only HEAD^ | grep -q 'src/tools/dbs-response-logger'; then
+            echo "publish-response-logger=true" >> $GITHUB_ENV
+          else
+            echo "publish-response-logger=false" >> $GITHUB_ENV
+          fi
+
+      - name: Print publish flags
+        run: |
+          echo "Publish Client Watcher: ${{ env.publish_client }}"
+          echo "Publish Response Logger: ${{ env.publish_response_logger }}"
+
       - name: Package Client Watcher
-        if: ${{ github.event.inputs.publish-client == 'true' }}
+        if: ${{ github.event.inputs.publish-client == 'true' || env.publish_client == 'true' }}
         run: |
           dotnet pack ./src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj \
             --configuration Release \
@@ -105,14 +131,14 @@ jobs:
             /p:PackAsTool=true
 
       - name: Publish Client Watcher
-        if: ${{ github.event.inputs.publish-client == 'true' }}
+        if: ${{ github.event.inputs.publish-client == 'true' || env.publish_client == 'true' }}
         run: |
           dotnet nuget push ./nukpg/${{env.client_name}}.${{ env.CLIENT_VERSION }}.nupkg \
             --source https://api.nuget.org/v3/index.json \
             --api-key ${{ secrets.NUGET_API_KEY }}
           
       - name: Package Response Logger
-        if: ${{ github.event.inputs.publish-response-logger == 'true' }}
+        if: ${{ github.event.inputs.publish-response-logger == 'true' || env.publish_response_logger == 'true' }}
         run: |
           dotnet pack ./src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj \
             --configuration Release \
@@ -121,7 +147,7 @@ jobs:
             /p:PackAsTool=true
           
       - name: Publish Response Logger
-        if: ${{ github.event.inputs.publish-response-logger == 'true' }}
+        if: ${{ github.event.inputs.publish-response-logger == 'true' || env.publish_response_logger == 'true' }}
         run: |
           dotnet nuget push ./nukpg/${{env.response_logger_name}}.${{ env.DBS_VERSION }}.nupkg \
             --source https://api.nuget.org/v3/index.json \

--- a/.github/workflows/gh-tag.yml
+++ b/.github/workflows/gh-tag.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+
 env:
   MAJOR_MINOR_VERSION: "0.0"
 

--- a/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -10,6 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.Client.Watcher</PackageId>
+        <PackageAsTool>true</PackageAsTool>
         <ToolCommandName>suiw</ToolCommandName>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -10,6 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
+        <PackageAsTool>true</PackageAsTool>
         <ToolCommandName>suidbsw</ToolCommandName>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>


### PR DESCRIPTION
First part to using nuget in the smoke tests. I believe we are not creating a dotnettoolsettings file so trying to fix that by adding <packageastool> based on some examples I have seen. Also updating the nuget publish pipeline to run whenever we push changes to the watchers.