### PR TITLE
feat: sui-429

### DIFF
--- a/src/tools/README_Clients_User_Manual.md
+++ b/src/tools/README_Clients_User_Manual.md
@@ -53,3 +53,16 @@ dotnet tool uninstall --global DFE.SUI.Client.Watcher
 ```bash
 dotnet tool uninstall --global DFE.SUI.DBS.Response.Logger.Watcher
 ```
+
+## Installing Windows 2022 server
+```bash
+Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile 'dotnet-install.ps1';
+
+./dotnet-install.ps1 -Version 9.0.300 -InstallDir 'C:\Program Files\dotnet\'
+
+dotnet nuget add source "https://api.nuget.org/v3/index.json" --name "nuget.org"
+
+dotnet tool install SUI.Client.Watcher --tool-path 'C:\Program Files\dotnet\tools'
+
+$env:Path = "C:\Program Files\dotnet\tools;$env:Path"
+```

--- a/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
+++ b/src/tools/client/SUI.Client.Watcher/SUI.Client.Watcher.csproj
@@ -10,7 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.Client.Watcher</PackageId>
-        <PackageAsTool>true</PackageAsTool>
+        <PackAsTool>true</PackAsTool>
         <ToolCommandName>suiw</ToolCommandName>
         <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -10,7 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
-        <PackageAsTool>true</PackageAsTool>
+        <PackAsTool>true</PackageAsTool>
         <ToolCommandName>suidbsw</ToolCommandName>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/SUI.DBS.Response.Logger.Watcher.csproj
@@ -10,7 +10,7 @@
         <Company>Department for Education</Company>
         <PackageProjectUrl>https://github.com/DFE-Digital/SUI_Matcher</PackageProjectUrl>
         <PackageId>SUI.DBS.Response.Logger.Watcher</PackageId>
-        <PackAsTool>true</PackageAsTool>
+        <PackAsTool>true</PackAsTool>
         <ToolCommandName>suidbsw</ToolCommandName>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>


### PR DESCRIPTION
After fighting with the serial console I finally got the runtimes and tools installed in usable locations. Firstly, you need the packAsTool directive so that it includes the necessary files to allow the dotnet cli to download it properly. Secondly, the environment we install to needs version 9 of the sdk. Additionally, we should specify the locations of our installs to ensure everythig is in path.