### PR TITLE
fix: watcher

### DIFF
--- a/src/tools/client/SUI.Client.Core/Watcher/CsvFileMonitor.cs
+++ b/src/tools/client/SUI.Client.Core/Watcher/CsvFileMonitor.cs
@@ -54,7 +54,7 @@ public class CsvFileMonitor
     {
         while (!cancellationToken.IsCancellationRequested)
         {
-            if (_fileQueue.TryDequeue(out var filePath))
+            if (_fileQueue.TryDequeue(out var filePath) && File.Exists(filePath))
             {
                 _logger.LogInformation("Discovered file: {fileName}", Path.GetFileName(filePath));
                 try
@@ -77,6 +77,8 @@ public class CsvFileMonitor
                     Interlocked.Increment(ref _errorCount);
                     LastOperation = new FileProcessedEnvelope(filePath, exception: ex);
                 }
+                
+                _logger.LogInformation("Finished processing file: {fileName}", Path.GetFileName(filePath));
                 Processed?.Invoke(this, LastOperation);
             }
             await Task.Delay(_config.ProcessingDelayMs, cancellationToken);

--- a/src/tools/client/SUI.Client.Core/Watcher/CsvFileMonitor.cs
+++ b/src/tools/client/SUI.Client.Core/Watcher/CsvFileMonitor.cs
@@ -77,7 +77,7 @@ public class CsvFileMonitor
                     Interlocked.Increment(ref _errorCount);
                     LastOperation = new FileProcessedEnvelope(filePath, exception: ex);
                 }
-                
+
                 _logger.LogInformation("Finished processing file: {fileName}", Path.GetFileName(filePath));
                 Processed?.Invoke(this, LastOperation);
             }

--- a/src/tools/client/SUI.Client.Core/Watcher/CsvFileWatcherService.cs
+++ b/src/tools/client/SUI.Client.Core/Watcher/CsvFileWatcherService.cs
@@ -33,7 +33,7 @@ public class CsvFileWatcherService : IDisposable
     private void OnCreated(object sender, FileSystemEventArgs e)
     {
         Count++;
-        _logger.LogInformation("New file detected: {Path}", Path.GetFileName(e.FullPath));
+        _logger.LogInformation("Detected file system event on file: {fileName}", e.Name);
         FileDetected?.Invoke(this, e.FullPath);
     }
 


### PR DESCRIPTION
This a minor bug where an exception is thrown because it's trying to run the same file twice when we move it. This is because of the FileSystemWatcher. See remarks: https://learn.microsoft.com/en-us/dotnet/api/system.io.filesystemwatcher.created?view=net-9.0