### PR TITLE
bugfix: remove the response in the log message

### DIFF
--- a/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
+++ b/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
@@ -62,7 +62,7 @@ public class CsvFileProcessor(ILogger<CsvFileProcessor> _logger, CsvMappingConfi
             };
 
             var response = await matchPersonApi.MatchPersonAsync(payload);
-            _logger.LogInformation("Received response: {Response}", response);
+            _logger.LogInformation("Received response");
 
             record[HeaderStatus] = response?.Result?.MatchStatus.ToString() ?? "-";
             record[HeaderScore] = response?.Result?.Score.ToString() ?? "-";


### PR DESCRIPTION
Removing the response in the log message as it will output NHS numbers to a log file