### PR TITLE
CI: remove workload from CI

### DIFF
--- a/.github/workflows/gh-deploy-app.yml
+++ b/.github/workflows/gh-deploy-app.yml
@@ -69,9 +69,6 @@ jobs:
       - name: Install azd
         uses: Azure/setup-azd@v2
 
-      - name: Install .NET Aspire workload
-        run: dotnet workload install aspire
-
       - name: Log in with Azure (Federated Credentials)
         if: ${{ env.AZURE_CLIENT_ID != '' }}
         run: |


### PR DESCRIPTION
Workload is not needed in .NET9 SDK as it's built in

https://learn.microsoft.com/en-us/dotnet/aspire/get-started/upgrade-to-aspire-9?utm_source=chatgpt.com&pivots=vscode