### PR TITLE
feat: add extra gender results

### DIFF
--- a/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Core/TextFileProcessor.cs
+++ b/src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Core/TextFileProcessor.cs
@@ -130,8 +130,14 @@ public class TxtFileProcessor(ILogger<TxtFileProcessor> logger) : ITxtFileProces
 
     public static string ToGender(string? value)
     {
-        var genderFromValue = value == "1" ? "Male" : "Female";
-        return !string.IsNullOrWhiteSpace(value) ? genderFromValue : "Unknown";
+        return value switch
+        {
+            "0" => "Not known",
+            "1" => "Male",
+            "2" => "Female",
+            "9" => "Not specified",
+            _ => "Unknown"
+        };
     }
 
     public static string ToPostCode(string? value)


### PR DESCRIPTION
From the DBS guide, there are 4 gender options https://digital.nhs.uk/developer/api-catalogue/demographics-batch-service#interactions

Currently we only use 2 with the fallback always being Female, so this fixes that.