### PR TITLE
CI: allow tools core package changes to publish nuget as well

### DIFF
--- a/.github/workflows/gh-publish-nuget.yml
+++ b/.github/workflows/gh-publish-nuget.yml
@@ -4,8 +4,8 @@ on:
     branches:
       - main
     paths:
-      - 'src/tools/client/SUI.Client.Watcher/**'
-      - 'src/tools/dbs-response-logger/SUI.DBS.Response.Logger.Watcher/**'
+      - 'src/tools/client/**'
+      - 'src/tools/dbs-response-logger/**'
   workflow_dispatch:
     inputs:
       publish-client:


### PR DESCRIPTION
Currently nuget CI only publishes if theres a change in the console directory.

This update means a change in the console or core library will trigger a change