### PR TITLE
SUI-571 applied soft delete and added purge protection to our Azure Key Vault

### DIFF
--- a/src/app-host/infra/secrets/secrets.module.bicep
+++ b/src/app-host/infra/secrets/secrets.module.bicep
@@ -19,6 +19,8 @@ resource secrets 'Microsoft.KeyVault/vaults@2023-07-01' = {
       name: 'standard'
     }
     enableRbacAuthorization: true
+    enableSoftDelete: true
+    enablePurgeProtection: true
   }
 }
 


### PR DESCRIPTION
Added the following settings
 
- `enableSoftDelete: true` makes sure the Key Vault can be recovered after deletion (within the default 90 retention period).
- `enablePurgeProtection: true` blocks permanent deletion even if someone tries to purge the soft-deleted vault.