### PR TITLE
chore: remove cloud infra for audit

### DIFF
--- a/src/app-host/infra/main.bicep
+++ b/src/app-host/infra/main.bicep
@@ -88,5 +88,5 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = resources.output
 output APPLICATION_INSIGHTS_CONNECTION_STRING string = resources.outputs.APPLICATION_INSIGHTS_CONNECTION_STRING
 output SECRETS_VAULTURI string = secrets.outputs.vaultUri
 
-output AZURE_ENABLE_AUDIT_LOGGING bool = enableAuditLogging
-output AZURE_TABLE_STORAGE_CONNECTION_STRING string = resources.outputs.tableEndpoint
+// output AZURE_ENABLE_AUDIT_LOGGING bool = enableAuditLogging
+// output AZURE_TABLE_STORAGE_CONNECTION_STRING string = resources.outputs.tableEndpoint

--- a/src/app-host/infra/main.parameters.json
+++ b/src/app-host/infra/main.parameters.json
@@ -22,9 +22,6 @@
       },
       "monitoringActionGroupEmail": {
         "value": "${AZURE_MONITORING_ACTION_GROUP_EMAIL}"
-      },
-      "enableAuditLogging": {
-        "value": "${AZURE_ENABLE_AUDIT_LOGGING}"
       }
     }
   }

--- a/src/app-host/infra/matching-api.tmpl.yaml
+++ b/src/app-host/infra/matching-api.tmpl.yaml
@@ -22,8 +22,6 @@ properties:
     secrets:
       - name: app-insights-connection-string
         value: '{{ .Env.APPLICATION_INSIGHTS_CONNECTION_STRING }}'
-      - name: azure-storage-connection-string
-        value: {{ .Env.AZURE_TABLE_STORAGE_CONNECTION_STRING }}
   template:
     containers:
       - image: {{ .Image }}
@@ -49,10 +47,6 @@ properties:
             value: {{ .Env.AZURE_ENV_NAME}}
           - name: APPLICATIONINSIGHTS_CONNECTION_STRING
             secretRef: app-insights-connection-string
-          - name: FeatureManagement__EnableAuditLogging
-            value: {{ .Env.AZURE_ENABLE_AUDIT_LOGGING }}
-          - name: ConnectionStrings__tables
-            secretRef: azure-storage-connection-string
           
     scale:
       minReplicas: 1

--- a/src/app-host/infra/resources.bicep
+++ b/src/app-host/infra/resources.bicep
@@ -141,35 +141,35 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-p
     }
   }
 }
-
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = if(enableAuditLogging) {
-  name: '${environmentPrefix}${lowercaseEnvironmentName}sa01'
-  location: location
-  sku: {
-    name: 'Standard_LRS'
-  }
-  kind: 'StorageV2'
-  tags: {
-      ...tags
-      'aspire-resource-name': 'az-storage'
-  }
-  properties: {
-    accessTier: 'Hot'
-    minimumTlsVersion: 'TLS1_2'
-  }
-}
-
-
-resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-01-01' = if(enableAuditLogging) {
-  parent: storageAccount
-  name: 'default'
-}
-
-resource tableServiceAuditTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-01' = if(enableAuditLogging) {
-  parent: tableService
-  name: 'AuditLogs'
-  properties: {}
-}
+// 
+// resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = if(enableAuditLogging) {
+//   name: '${environmentPrefix}${lowercaseEnvironmentName}sa01'
+//   location: location
+//   sku: {
+//     name: 'Standard_LRS'
+//   }
+//   kind: 'StorageV2'
+//   tags: {
+//       ...tags
+//       'aspire-resource-name': 'az-storage'
+//   }
+//   properties: {
+//     accessTier: 'Hot'
+//     minimumTlsVersion: 'TLS1_2'
+//   }
+// }
+// 
+// 
+// resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-01-01' = if(enableAuditLogging) {
+//   parent: storageAccount
+//   name: 'default'
+// }
+// 
+// resource tableServiceAuditTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-01' = if(enableAuditLogging) {
+//   parent: tableService
+//   name: 'AuditLogs'
+//   properties: {}
+// }
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: '${environmentPrefix}-${lowercaseEnvironmentName}-appinsights-01'
@@ -197,11 +197,11 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
 output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
 output APPLICATION_INSIGHTS_CONNECTION_STRING string = applicationInsights.properties.ConnectionString
 
-output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
-
-output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue
-
-output tableEndpoint string = storageAccount.properties.primaryEndpoints.table
-
-output name string = storageAccount.name
+// output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+// 
+// output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue
+// 
+// output tableEndpoint string = storageAccount.properties.primaryEndpoints.table
+// 
+// output name string = storageAccount.name
 


### PR DESCRIPTION
Remove cloud infra for audit until we need it. Otherwise it's causing deployment issues due to still wanting connection strings.

Commented out most of it but some needed to be deleted.