### PR TITLE
feat: SUI 705 optional fields

### DIFF
--- a/src/Shared/Models/PersonSpecification.cs
+++ b/src/Shared/Models/PersonSpecification.cs
@@ -56,4 +56,7 @@ public class PersonSpecification
     [RegularExpression("^(([A-Z][0-9]{1,2})|(([A-Z][A-HJ-Y][0-9]{1,2})|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2}$", ErrorMessage = PersonValidationConstants.PostCodeInvalid)]
     [JsonPropertyName("addresspostalcode")]
     public string? AddressPostalCode { get; set; }
+
+    [JsonPropertyName("optionalProperties")]
+    public Dictionary<string, object> OptionalProperties { get; set; } = new();
 }

--- a/src/matching-api/Services/MatchingService.cs
+++ b/src/matching-api/Services/MatchingService.cs
@@ -9,6 +9,8 @@ using Shared.Logging;
 using Shared.Models;
 using Shared.Util;
 
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
 namespace MatchingApi.Services;
 
 public class MatchingService(
@@ -138,7 +140,7 @@ public class MatchingService(
             personSpecification.Gender ?? "Unknown",
             personSpecification.AddressPostalCode ?? "Unknown",
             JsonConvert.SerializeObject(dataQualityResult.ToDictionary()),
-            JsonConvert.SerializeObject(personSpecification.OptionalProperties)
+            JsonSerializer.Serialize(personSpecification.OptionalProperties)
         );
     }
 

--- a/src/matching-api/Services/MatchingService.cs
+++ b/src/matching-api/Services/MatchingService.cs
@@ -130,14 +130,15 @@ public class MatchingService(
             : "Unknown";
 
         logger.LogInformation(
-            "[MATCH_COMPLETED] [ConfidenceScore={Score}] [ProcessStage={Stage}] MatchStatus: {MatchStatus}, AgeGroup: {AgeGroup}, Gender: {Gender}, Postcode: {Postcode}, DataQuality: {DataQuality}",
+            "[MATCH_COMPLETED] [ConfidenceScore={Score}] [ProcessStage={Stage}] MatchStatus: {MatchStatus}, AgeGroup: {AgeGroup}, Gender: {Gender}, Postcode: {Postcode}, DataQuality: {DataQuality}, OptionalProperties: {OptionalProperties}",
             score,
             resultProcessStage,
             matchStatus,
             ageGroup,
             personSpecification.Gender ?? "Unknown",
             personSpecification.AddressPostalCode ?? "Unknown",
-            JsonConvert.SerializeObject(dataQualityResult.ToDictionary())
+            JsonConvert.SerializeObject(dataQualityResult.ToDictionary()),
+            JsonConvert.SerializeObject(personSpecification.OptionalProperties)
         );
     }
 

--- a/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
+++ b/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
@@ -84,8 +84,8 @@ public class CsvFileProcessor(ILogger<CsvFileProcessor> logger, CsvMappingConfig
                 Email = record.GetFirstValueOrDefault(mapping.ColumnMappings[nameof(MatchPersonPayload.Email)]),
                 AddressPostalCode = record.GetFirstValueOrDefault(mapping.ColumnMappings[nameof(MatchPersonPayload.AddressPostalCode)]),
                 Gender = watcherConfig.Value.EnableGenderSearch ? gender : null,
+                OptionalFields = GetOptionalFields(record)
             };
-
 
             var response = await matchPersonApi.MatchPersonAsync(payload);
 
@@ -106,6 +106,46 @@ public class CsvFileProcessor(ILogger<CsvFileProcessor> logger, CsvMappingConfig
         var statsJsonFileName = WriteStatsJsonFile(outputDirectory, ts, stats);
 
         return new ProcessCsvFileResult(outputFilePath, statsJsonFileName, pdfReport, stats, outputDirectory);
+    }
+
+    private static Dictionary<string, object> GetOptionalFields(Dictionary<string, string> record)
+    {
+        // As we cannot guarantee the presence of these fields in the CSV, we will check and only add them if they exist and are non-empty.
+        var optionalFields = new Dictionary<string, object>();
+        var activeCin = record.GetFirstValueOrDefault(["ActiveCIN"]);
+        var activeCla = record.GetFirstValueOrDefault(["ActiveCLA"]);
+        var activeCp = record.GetFirstValueOrDefault(["ActiveCP"]);
+        var activeEhm = record.GetFirstValueOrDefault(["ActiveEHM"]);
+        var ethnicity = record.GetFirstValueOrDefault(["Ethnicity"]);
+        var immigrationStatus = record.GetFirstValueOrDefault(["ImmigrationStatus"]);
+        if (!string.IsNullOrWhiteSpace(activeCin))
+        {
+            optionalFields.TryAdd("ActiveCIN", activeCin);
+        }
+        if (!string.IsNullOrWhiteSpace(activeCla))
+        {
+            optionalFields.TryAdd("ActiveCLA", activeCla);
+        }
+        if (!string.IsNullOrWhiteSpace(activeCp))
+        {
+            optionalFields.TryAdd("ActiveCP", activeCp);
+        }
+        if (!string.IsNullOrWhiteSpace(activeEhm))
+        {
+            optionalFields.TryAdd("ActiveEHM", activeEhm);
+        }
+
+        if (!string.IsNullOrWhiteSpace(ethnicity))
+        {
+            optionalFields.TryAdd("Ethnicity", ethnicity);
+        }
+
+        if (!string.IsNullOrWhiteSpace(immigrationStatus))
+        {
+            optionalFields.TryAdd("ImmigrationStatus", immigrationStatus);
+        }
+
+        return optionalFields;
     }
 
 

--- a/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
+++ b/src/tools/client/SUI.Client.Core/CsvFileProcessor.cs
@@ -84,7 +84,7 @@ public class CsvFileProcessor(ILogger<CsvFileProcessor> logger, CsvMappingConfig
                 Email = record.GetFirstValueOrDefault(mapping.ColumnMappings[nameof(MatchPersonPayload.Email)]),
                 AddressPostalCode = record.GetFirstValueOrDefault(mapping.ColumnMappings[nameof(MatchPersonPayload.AddressPostalCode)]),
                 Gender = watcherConfig.Value.EnableGenderSearch ? gender : null,
-                OptionalFields = GetOptionalFields(record)
+                OptionalProperties = GetOptionalFields(record)
             };
 
             var response = await matchPersonApi.MatchPersonAsync(payload);

--- a/src/tools/client/SUI.Client.Core/Models/MatchPersonPayload.cs
+++ b/src/tools/client/SUI.Client.Core/Models/MatchPersonPayload.cs
@@ -9,4 +9,5 @@ public class MatchPersonPayload
     public string? Phone { get; set; }
     public string? Email { get; set; }
     public string? AddressPostalCode { get; set; }
+    public Dictionary<string, object> OptionalFields { get; set; } = new();
 }

--- a/src/tools/client/SUI.Client.Core/Models/MatchPersonPayload.cs
+++ b/src/tools/client/SUI.Client.Core/Models/MatchPersonPayload.cs
@@ -9,5 +9,5 @@ public class MatchPersonPayload
     public string? Phone { get; set; }
     public string? Email { get; set; }
     public string? AddressPostalCode { get; set; }
-    public Dictionary<string, object> OptionalFields { get; set; } = new();
+    public Dictionary<string, object> OptionalProperties { get; set; } = new();
 }

--- a/tests/Unit.Tests/Client/ProcessCsVFileAsyncTests.cs
+++ b/tests/Unit.Tests/Client/ProcessCsVFileAsyncTests.cs
@@ -56,12 +56,12 @@ public class ProcessCsVFileAsyncTests
         await processor.ProcessCsvFileAsync(filePath, outputPath);
 
         Assert.NotNull(capturedPayload);
-        Assert.Equal("CIN123", capturedPayload!.OptionalFields["ActiveCIN"]);
-        Assert.Equal("CLA456", capturedPayload.OptionalFields["ActiveCLA"]);
-        Assert.Equal("CP789", capturedPayload.OptionalFields["ActiveCP"]);
-        Assert.Equal("EHM321", capturedPayload.OptionalFields["ActiveEHM"]);
-        Assert.Equal("A1 - White-British", capturedPayload.OptionalFields["Ethnicity"]);
-        Assert.Equal("Settled", capturedPayload.OptionalFields["ImmigrationStatus"]);
+        Assert.Equal("CIN123", capturedPayload!.OptionalProperties["ActiveCIN"]);
+        Assert.Equal("CLA456", capturedPayload.OptionalProperties["ActiveCLA"]);
+        Assert.Equal("CP789", capturedPayload.OptionalProperties["ActiveCP"]);
+        Assert.Equal("EHM321", capturedPayload.OptionalProperties["ActiveEHM"]);
+        Assert.Equal("A1 - White-British", capturedPayload.OptionalProperties["Ethnicity"]);
+        Assert.Equal("Settled", capturedPayload.OptionalProperties["ImmigrationStatus"]);
 
         // Clean up
         if (File.Exists(filePath))

--- a/tests/Unit.Tests/Client/ProcessCsVFileAsyncTests.cs
+++ b/tests/Unit.Tests/Client/ProcessCsVFileAsyncTests.cs
@@ -1,0 +1,55 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+using Moq;
+
+using Shared.Models;
+
+using SUI.Client.Core;
+using SUI.Client.Core.Integration;
+using SUI.Client.Core.Models;
+using SUI.Client.Core.Watcher;
+
+namespace Unit.Tests.Client;
+
+public class ProcessCsVFileAsyncTests
+{
+    [Fact]
+    public async Task ProcessCsvFileAsync_PassesOptionalFieldsToMatchPersonAsync()
+    {
+        var mockLogger = new Mock<ILogger<CsvFileProcessor>>();
+        var mockApi = new Mock<IMatchPersonApiService>();
+        var mapping = new CsvMappingConfig { /* set up mappings as needed */ };
+        var watcherConfig = Options.Create(new CsvWatcherConfig { EnableGenderSearch = true });
+
+        MatchPersonPayload? capturedPayload = null;
+        mockApi.Setup(x => x.MatchPersonAsync(It.IsAny<MatchPersonPayload>()))
+            .Callback<MatchPersonPayload>(p => capturedPayload = p)
+            .ReturnsAsync(new PersonMatchResponse());
+
+        var processor = new CsvFileProcessor(mockLogger.Object, mapping, mockApi.Object, watcherConfig);
+
+        // Prepare test CSV file with optional fields
+        var tempDir = Path.GetTempPath();
+        var filePath = Path.Combine(tempDir, "test.csv");
+        var outputPath = tempDir;
+        var headers = new HashSet<string> { "Given", "Family", "ActiveCIN", "Ethnicity" };
+        var records = new List<Dictionary<string, string>>
+        {
+            new() { ["Given"] = "Jane", ["Family"] = "Doe", ["ActiveCIN"] = "CIN123", ["Ethnicity"] = "A1 - White-British" }
+        };
+        await CsvFileProcessor.WriteCsvAsync(filePath, headers, records);
+
+        await processor.ProcessCsvFileAsync(filePath, outputPath);
+
+        Assert.NotNull(capturedPayload);
+        Assert.True(capturedPayload!.OptionalFields.ContainsKey("ActiveCIN"));
+        Assert.Equal("CIN123", capturedPayload.OptionalFields["ActiveCIN"]);
+        Assert.True(capturedPayload.OptionalFields.ContainsKey("Ethnicity"));
+        Assert.Equal("A1 - White-British", capturedPayload.OptionalFields["Ethnicity"]);
+
+        // Clean up
+        if (File.Exists(filePath))
+            File.Delete(filePath);
+    }
+}

--- a/tests/Unit.Tests/Matching/MatchingServiceTests.cs
+++ b/tests/Unit.Tests/Matching/MatchingServiceTests.cs
@@ -50,7 +50,7 @@ public sealed class MatchingServiceTests
         };
 
         // Act 
-        var result = await _sut.SearchAsync(personSpecification);
+        await _sut.SearchAsync(personSpecification);
 
         // Assert
         _loggerMock.Verify(logger => logger.Log(

--- a/tests/Unit.Tests/Matching/MatchingServiceTests.cs
+++ b/tests/Unit.Tests/Matching/MatchingServiceTests.cs
@@ -30,6 +30,39 @@ public sealed class MatchingServiceTests
     }
 
     [Fact]
+    public async Task ShouldLogOptionalProperties_WhenProvidedInPersonSpecification()
+    {
+        // Arrange
+        PersonSpecification personSpecification = new()
+        {
+            AddressPostalCode = "TQ12 5HH",
+            BirthDate = new DateOnly(2000, 11, 11),
+            Email = "test@test.com",
+            Family = "Smith",
+            Given = "John",
+            Gender = "male",
+            Phone = "000000000",
+            OptionalProperties = new Dictionary<string, object>
+            {
+                { "CustomProperty1", "Value1" },
+                { "CustomProperty2", "Value2" }
+            }
+        };
+
+        // Act 
+        var result = await _sut.SearchAsync(personSpecification);
+
+        // Assert
+        _loggerMock.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("CustomProperty1") && v.ToString()!.Contains("Value1") &&
+                                          v.ToString()!.Contains("CustomProperty2") && v.ToString()!.Contains("Value2")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.AtLeastOnce);
+    }
+
+    [Fact]
     public async Task EmptyPersonModelReturnsError()
     {
         var result = await _sut.SearchAsync(new PersonSpecification());


### PR DESCRIPTION
- Updated API to log any optional fields being passed to it using a dictionary as it was the simplest and most readable. 
- Updated Client to specifically look out for the specified fields.
- Added tests to support API and client

Note: Client is looking for specific fields because there is now way to know what we class as optional programatically. Any changes however only need to be updated on the client.