### PR TITLE
refactor: SUI-1666 - extract shared app-host IaC modules

### DIFF
--- a/src/app-host/infra/main.bicep
+++ b/src/app-host/infra/main.bicep
@@ -33,6 +33,8 @@ param monitoringActionGroupEmail string
 param turnOnAlerts bool = false
 
 @description('Enable Audit Logging feature for Aspire application')
+// Preserved for compatibility with the existing audit deployment docs and parameter surface.
+#disable-next-line no-unused-params
 param enableAuditLogging bool = false
 
 var tags = {
@@ -53,7 +55,6 @@ module resources 'resources.bicep' = {
     containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
     containerAppVnet: containerAppVnet
     containerAppEnvSubnet: containerAppEnvSubnet
-    enableAuditLogging: enableAuditLogging
   }
 }
 

--- a/src/app-host/infra/modules/container-app-environment.bicep
+++ b/src/app-host/infra/modules/container-app-environment.bicep
@@ -1,0 +1,99 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('container app managed environment number')
+param containerAppManagedEnvironmentNumber string
+
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@description('Container App environment subnet')
+param containerAppEnvSubnet string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('The Log Analytics workspace name used by the container app environment')
+param logAnalyticsWorkspaceName string
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
+  name: logAnalyticsWorkspaceName
+}
+
+resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}-vnet-cae-01'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        containerAppVnet
+      ]
+    }
+    subnets: [
+      {
+        name: '${environmentPrefix}-${lowercaseEnvironmentName}-subnet-cae-01'
+        properties: {
+          addressPrefix: containerAppEnvSubnet
+          delegations: [
+            {
+              name: 'Microsoft.App.environments'
+              properties: {
+                serviceName: 'Microsoft.App/environments'
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}-cae-${containerAppManagedEnvironmentNumber}'
+  location: location
+  tags: tags
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspace.properties.customerId
+        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
+      }
+    }
+    workloadProfiles: [
+      {
+        name: 'default'
+        workloadProfileType: 'D4'
+        minimumCount: 1
+        maximumCount: 1
+      }
+    ]
+    peerTrafficConfiguration: {
+      encryption: {
+        enabled: true
+      }
+    }
+    publicNetworkAccess: 'Disabled' // For Pen Test destroy cae and rebuild with that set to Enabled
+    vnetConfiguration: {
+      infrastructureSubnetId: '${caeVnet.id}/subnets/${environmentPrefix}-${lowercaseEnvironmentName}-subnet-cae-01'
+      internal: true // For Pen Test destroy cae and rebuild with this value removed
+    }
+  }
+
+  resource aspireDashboard 'dotNetComponents' = {
+    name: '${environmentPrefix}-${lowercaseEnvironmentName}-dashboard-01'
+    properties: {
+      componentType: 'AspireDashboard'
+    }
+  }
+}
+
+output name string = containerAppEnvironment.name
+output id string = containerAppEnvironment.id
+output defaultDomain string = containerAppEnvironment.properties.defaultDomain

--- a/src/app-host/infra/modules/container-registry.bicep
+++ b/src/app-host/infra/modules/container-registry.bicep
@@ -1,0 +1,24 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+// The resource name can only contain alphanumeric characters.
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: '${environmentPrefix}${lowercaseEnvironmentName}acr01'
+  location: location
+  sku: {
+    name: 'Basic'
+  }
+  tags: tags
+}
+
+output endpoint string = containerRegistry.properties.loginServer
+output name string = containerRegistry.name

--- a/src/app-host/infra/modules/identity.bicep
+++ b/src/app-host/infra/modules/identity.bicep
@@ -1,0 +1,22 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}-mi-01'
+  location: location
+  tags: tags
+}
+
+output clientId string = managedIdentity.properties.clientId
+output name string = managedIdentity.name
+output principalId string = managedIdentity.properties.principalId
+output id string = managedIdentity.id

--- a/src/app-host/infra/modules/observability.bicep
+++ b/src/app-host/infra/modules/observability.bicep
@@ -1,0 +1,61 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}-loganalytics-01'
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'PerGB2018'
+    }
+  }
+}
+
+resource loganalyticsDbsConsoleApplogs 'Microsoft.OperationalInsights/workspaces/tables@2025-02-01' = {
+  parent: logAnalyticsWorkspace
+  name: 'DbsClientConsoleApplogs_CL'
+  properties: {
+    totalRetentionInDays: 30
+    plan: 'Analytics'
+    schema: {
+      name: 'DbsClientConsoleApplogs_CL'
+      columns: [
+        {
+          name: 'Message'
+          type: 'string'
+        }
+        {
+          name: 'TimeGenerated'
+          type: 'datetime'
+        }
+      ]
+    }
+    retentionInDays: 30
+  }
+}
+
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}-appinsights-01'
+  location: location
+  kind: 'web'
+  tags: tags
+  properties: {
+    Application_Type: 'web'
+    Flow_Type: 'Bluefield'
+    WorkspaceResourceId: logAnalyticsWorkspace.id
+  }
+}
+
+output workspaceName string = logAnalyticsWorkspace.name
+output workspaceId string = logAnalyticsWorkspace.id
+output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString

--- a/src/app-host/infra/resources.bicep
+++ b/src/app-host/infra/resources.bicep
@@ -19,189 +19,61 @@ param containerAppEnvSubnet string
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
-@description('Turn on Azure storage account, use for logging auditing')
-param enableAuditLogging bool = false
-
 var lowercaseEnvironmentName = toLower(environmentName)
 
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-mi-01'
-  location: location
-  tags: tags
-}
-
-// The below resource can only contain alpha numeric characters - facepalm!
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
-  name: '${environmentPrefix}${lowercaseEnvironmentName}acr01'
-  location: location
-  sku: {
-    name: 'Basic'
-  }
-  tags: tags
-}
-
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-loganalytics-01'
-  location: location
-  tags: tags
-  properties: {
-    sku: {
-      name: 'PerGB2018'
-    }
+module identity 'modules/identity.bicep' = {
+  name: 'identity'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
   }
 }
 
-resource loganalyticsDbsConsoleApplogs 'Microsoft.OperationalInsights/workspaces/tables@2025-02-01' = {
-  parent: logAnalyticsWorkspace
-  name: 'DbsClientConsoleApplogs_CL'
-  properties: {
-    totalRetentionInDays: 30
-    plan: 'Analytics'
-    schema: {
-      name: 'DbsClientConsoleApplogs_CL'
-      columns: [
-        {
-          name: 'Message'
-          type: 'string'
-        }
-        {
-          name: 'TimeGenerated'
-          type: 'datetime'
-        }
-      ]
-    }
-    retentionInDays: 30
+module containerRegistry 'modules/container-registry.bicep' = {
+  name: 'container-registry'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
   }
 }
 
-resource caevnets 'Microsoft.Network/virtualNetworks@2022-07-01' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-vnet-cae-01'
-  location: location
-  properties: {
-    addressSpace: {
-      addressPrefixes: [
-        containerAppVnet
-      ]
-    }
-    subnets: [
-      {
-        name: '${environmentPrefix}-${lowercaseEnvironmentName}-subnet-cae-01'
-        properties: {
-          addressPrefix: containerAppEnvSubnet
-          delegations: [
-            {
-              name: 'Microsoft.App.environments'
-              properties: {
-                serviceName: 'Microsoft.App/environments'
-              }
-            }
-          ]
-        }
-      }
-    ]
+module observability 'modules/observability.bicep' = {
+  name: 'observability'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
   }
 }
 
-resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-cae-${containerAppManagedEnvironmentNumber}'
-  location: location
-  tags: tags
-  properties: {
-    appLogsConfiguration: {
-      destination: 'log-analytics'
-      logAnalyticsConfiguration: {
-        customerId: logAnalyticsWorkspace.properties.customerId
-        sharedKey: logAnalyticsWorkspace.listKeys().primarySharedKey
-      }
-    }
-    workloadProfiles: [
-      {
-        name: 'default'
-        workloadProfileType: 'D4'
-        minimumCount: 1
-        maximumCount: 1
-      }
-    ]
-    peerTrafficConfiguration: {
-      encryption: {
-        enabled: true
-      }
-    }
-    publicNetworkAccess: 'Disabled' // For Pen Test destroy cae and rebuild with that set to Enabled
-    vnetConfiguration: {
-      infrastructureSubnetId: '${caevnets.id}/subnets/${environmentPrefix}-${lowercaseEnvironmentName}-subnet-cae-01'
-      internal: true // For Pen Test destroy cae and rebuild with this value removed
-    }
-  }
-
-  resource aspireDashboard 'dotNetComponents' = {
-    name: '${environmentPrefix}-${lowercaseEnvironmentName}-dashboard-01'
-    properties: {
-      componentType: 'AspireDashboard'
-    }
-  }
-}
-// 
-// resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = if(enableAuditLogging) {
-//   name: '${environmentPrefix}${lowercaseEnvironmentName}sa01'
-//   location: location
-//   sku: {
-//     name: 'Standard_LRS'
-//   }
-//   kind: 'StorageV2'
-//   tags: {
-//       ...tags
-//       'aspire-resource-name': 'az-storage'
-//   }
-//   properties: {
-//     accessTier: 'Hot'
-//     minimumTlsVersion: 'TLS1_2'
-//   }
-// }
-// 
-// 
-// resource tableService 'Microsoft.Storage/storageAccounts/tableServices@2023-01-01' = if(enableAuditLogging) {
-//   parent: storageAccount
-//   name: 'default'
-// }
-// 
-// resource tableServiceAuditTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-01-01' = if(enableAuditLogging) {
-//   parent: tableService
-//   name: 'AuditLogs'
-//   properties: {}
-// }
-
-resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-appinsights-01'
-  location: location
-  kind: 'web'
-  tags: tags
-  properties: {
-    Application_Type: 'web'
-    Flow_Type: 'Bluefield'
-    WorkspaceResourceId: logAnalyticsWorkspace.id
+module containerAppEnvironment 'modules/container-app-environment.bicep' = {
+  name: 'container-app-environment'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
+    containerAppVnet: containerAppVnet
+    containerAppEnvSubnet: containerAppEnvSubnet
+    tags: tags
+    logAnalyticsWorkspaceName: observability.outputs.workspaceName
   }
 }
 
-
-output MANAGED_IDENTITY_CLIENT_ID string = managedIdentity.properties.clientId
-output MANAGED_IDENTITY_NAME string = managedIdentity.name
-output MANAGED_IDENTITY_PRINCIPAL_ID string = managedIdentity.properties.principalId
-output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = logAnalyticsWorkspace.name
-output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = logAnalyticsWorkspace.id
-output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
-output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = managedIdentity.id
-output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.name
-output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = containerAppEnvironment.name
-output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.id
-output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.properties.defaultDomain
-output APPLICATION_INSIGHTS_CONNECTION_STRING string = applicationInsights.properties.ConnectionString
-
-// output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
-// 
-// output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue
-// 
-// output tableEndpoint string = storageAccount.properties.primaryEndpoints.table
-// 
-// output name string = storageAccount.name
-
+output MANAGED_IDENTITY_CLIENT_ID string = identity.outputs.clientId
+output MANAGED_IDENTITY_NAME string = identity.outputs.name
+output MANAGED_IDENTITY_PRINCIPAL_ID string = identity.outputs.principalId
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = observability.outputs.workspaceName
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = observability.outputs.workspaceId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.endpoint
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = identity.outputs.id
+output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = containerAppEnvironment.outputs.name
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.outputs.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.outputs.defaultDomain
+output APPLICATION_INSIGHTS_CONNECTION_STRING string = observability.outputs.applicationInsightsConnectionString


### PR DESCRIPTION
## Summary
This PR refactors the shared app-host deployment IaC by extracting the common Azure resources from `resources.bicep` into reusable Bicep modules. The aim is to keep the current deployment path unchanged while making the infrastructure easier to reuse in later stack-based refactors.

## Changes
- Extract shared app-host IaC resources into reusable modules under `src/app-host/infra/modules`
- Refactor `src/app-host/infra/resources.bicep` to compose those modules instead of declaring the shared resources inline
- Keep the existing `main.bicep` output contract intact for downstream deployment usage

## Validation
- Ran `az bicep build` successfully for `src/app-host/infra/main.bicep`
- Compared the compiled pre-refactor and post-refactor templates locally to confirm the same effective shared infrastructure/resources are declared
- Ran `.github/workflows/gh-deploy-infra.yml` with `what_if=true` and `use_current_branch=true`
  - Compared the `what-if` output against `main` and saw the same set of changes, indicating this refactor does not introduce additional infrastructure differences
	  - [Branch run](https://github.com/DFE-Digital/SUI_Matcher/actions/runs/24399962865)
	  - [main run](https://github.com/DFE-Digital/SUI_Matcher/actions/runs/24399869841)