### PR TITLE
docs: SUI-1676 - add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,47 @@
+<!--
+Ensure PR title follows the conventional commit format with a ticket reference:
+<type>: SUI-1234 - concise description
+-->
+
+## Summary
+
+<!--
+Describe the intent of the PR at a high level:
+- what problem or need this change addresses
+- why this approach was taken
+- any important scope or non-goals if they matter for review
+-->
+
+## Changes
+
+<!--
+List the concrete changes in reviewer-friendly bullets.
+Keep this focused on the meaningful implementation/documentation changes.
+-->
+
+-
+-
+-
+
+## Validation
+
+<!--
+List how you validated the change.
+Examples:
+- Unit/integration/E2E tests run
+- Manual validation steps
+- Terraform plan/apply environments
+- Docs-only change; no code/runtime validation required
+-->
+
+-
+-
+-
+
+<!--
+Optional: add extra context below when relevant, for example:
+- deferred findings or follow-up work
+- rollout notes
+- known limitations
+- reviewer-specific context
+-->


### PR DESCRIPTION
## Summary
This PR adds a default GitHub pull request template for the repository. It standardises PR descriptions around the structure already used in recent repo changes, making it easier to describe scope, key changes, and validation consistently.

## Changes
- Add `.github/pull_request_template.md`
- Include hidden guidance for authors on what to cover in each section

## Validation
- Docs-only change; no code/runtime validation required