### PR TITLE
feat: 1620 - write successful results to success dir

### DIFF
--- a/scripts/test-storage-process-function.ps1
+++ b/scripts/test-storage-process-function.ps1
@@ -75,13 +75,13 @@ if (-not [string]::IsNullOrWhiteSpace($directory)) {
 
 # PDS test data https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/pds-fhir-api-test-data#general-tests
 $csvContent = @"
-GivenName,FamilyName,DOB,Postcode
-octavia,chislett,2008-09-20,
-beryl,shipperbottom,2011-05-09,KT21 1LJ
-briar,anderton,2009-02-15,KT21 1JA
-percy,gilman,2011-01-28,KT21 1EJ
-red,flindall,2011-05-17,KT20 6XJ
-monte,fielding,2008-05-21,KT21 1DJ
+Id,GivenName,FamilyName,DOB,Postcode
+1001,octavia,chislett,2008-09-20,
+1002,beryl,shipperbottom,2011-05-09,KT21 1LJ
+1003,briar,anderton,2009-02-15,KT21 1JA
+1004,percy,gilman,2011-01-28,KT21 1EJ
+1005,red,flindall,2011-05-17,KT20 6XJ
+1006,monte,fielding,2008-05-21,KT21 1DJ
 "@
 
 Set-Content -Path $LocalFilePath -Value $csvContent -Encoding utf8NoBOM

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvHeaderValidator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvHeaderValidator.cs
@@ -8,6 +8,7 @@ public static class CsvHeaderValidator
         {
             CsvParserNameConstants.TypeOne => new[]
             {
+                "Id",
                 "GivenName",
                 "FamilyName",
                 "DOB",

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
@@ -49,7 +49,6 @@ public sealed class BlobFileOrchestrator(
             cancellationToken
         );
 
-        // Just logging for now. Next: Process results
         logger.LogInformation(
             "Completed processing blob {BlobName}. Total records: {TotalRecords}, Successful matches: {SuccessfulMatches}.",
             queueMessage.BlobName,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
@@ -14,6 +14,7 @@ public sealed class BlobFileOrchestrator(
     TimeProvider timeProvider,
     IBlobStorageClient blobStorageClient,
     IMatchPersonRecordOrchestrator<CsvRecordDto> matchPersonRecordOrchestrator,
+    ISuccessMatchFileWriter successMatchFileWriter,
     IOptions<StorageProcessJobOptions> options
 ) : IBlobFileOrchestrator
 {
@@ -54,6 +55,12 @@ public sealed class BlobFileOrchestrator(
             queueMessage.BlobName,
             matchedResults.Count,
             matchedResults.Count(r => r.IsSuccess)
+        );
+
+        await successMatchFileWriter.WriteAsync(
+            queueMessage.BlobName!,
+            matchedResults,
+            cancellationToken
         );
 
         var processedBlobName = BuildProcessedBlobName(queueMessage.BlobName!);

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/BlobFileOrchestrator.cs
@@ -50,7 +50,7 @@ public sealed class BlobFileOrchestrator(
         );
 
         logger.LogInformation(
-            "Completed processing blob {BlobName}. Total records: {TotalRecords}, Successful matches: {SuccessfulMatches}.",
+            "Completed processing blob {BlobName}. Total records: {TotalRecords}, Successful requests: {SuccessfulRequests}.",
             queueMessage.BlobName,
             matchedResults.Count,
             matchedResults.Count(r => r.IsSuccess)

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/IBlobStorageClient.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/IBlobStorageClient.cs
@@ -7,6 +7,14 @@ public interface IBlobStorageClient
         CancellationToken cancellationToken
     );
 
+    Task UploadBlobAsync(
+        string destinationContainerName,
+        string destinationBlobName,
+        BinaryData content,
+        string contentType,
+        CancellationToken cancellationToken
+    );
+
     Task ArchiveProcessedAsync(
         StorageBlobMessage blobMessage,
         string destinationContainerName,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
@@ -5,6 +5,10 @@ namespace SUI.Client.StorageProcessJob.Application.Interfaces;
 
 public interface ISuccessMatchFileWriter
 {
+    /// <summary>
+    /// Writer to filter out and write successful matches with a confident score
+    /// to a new CSV file in blob storage.
+    /// </summary>
     Task WriteAsync(
         string sourceBlobName,
         IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
@@ -6,8 +6,8 @@ namespace SUI.Client.StorageProcessJob.Application.Interfaces;
 public interface ISuccessMatchFileWriter
 {
     /// <summary>
-    /// Writer to filter out and write successful matches with a confident score
-    /// to a new CSV file in blob storage.
+    /// Filter on successful matches with a confident score
+    /// and write to a new CSV file in blob storage.
     /// <para>Records that fail validation fail silently and are logged</para>
     /// </summary>
     Task WriteAsync(

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
@@ -8,6 +8,7 @@ public interface ISuccessMatchFileWriter
     /// <summary>
     /// Writer to filter out and write successful matches with a confident score
     /// to a new CSV file in blob storage.
+    /// <para>Records that fail validation fail silently and are logged</para>
     /// </summary>
     Task WriteAsync(
         string sourceBlobName,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/Interfaces/ISuccessMatchFileWriter.cs
@@ -1,0 +1,13 @@
+using SUI.Client.Core.Application.Models;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
+
+namespace SUI.Client.StorageProcessJob.Application.Interfaces;
+
+public interface ISuccessMatchFileWriter
+{
+    Task WriteAsync(
+        string sourceBlobName,
+        IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
+        CancellationToken cancellationToken
+    );
+}

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -13,7 +13,7 @@ public sealed class SuccessMatchFileWriter(
     IOptions<StorageProcessJobOptions> options
 ) : ISuccessMatchFileWriter
 {
-    private const string IdHeader = "LLId";
+    private const string IdHeader = "LL ID";
     private const string TypeHeader = "Type";
     private const string NhsNumberHeader = "NhsNumber";
     private const string InputIdHeader = "Id";

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -7,13 +7,6 @@ using SUI.Client.StorageProcessJob.Application.Interfaces;
 
 namespace SUI.Client.StorageProcessJob.Application;
 
-/// <summary>
-/// Writer to filter out and write successful matches with a confident score
-/// to a new CSV file in blob storage.
-/// </summary>
-/// <param name="timeProvider"></param>
-/// <param name="blobStorageClient"></param>
-/// <param name="options"></param>
 public sealed class SuccessMatchFileWriter(
     TimeProvider timeProvider,
     IBlobStorageClient blobStorageClient,
@@ -27,6 +20,7 @@ public sealed class SuccessMatchFileWriter(
     private const string NhsNoType = "NHSNo";
     private const string CsvContentType = "text/csv";
 
+    /// <inheritdoc/>
     public async Task WriteAsync(
         string sourceBlobName,
         IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
@@ -9,6 +10,7 @@ namespace SUI.Client.StorageProcessJob.Application;
 
 public sealed class SuccessMatchFileWriter(
     TimeProvider timeProvider,
+    ILogger<SuccessMatchFileWriter> logger,
     IBlobStorageClient blobStorageClient,
     IOptions<StorageProcessJobOptions> options
 ) : ISuccessMatchFileWriter
@@ -27,12 +29,21 @@ public sealed class SuccessMatchFileWriter(
         CancellationToken cancellationToken
     )
     {
-        var successfulMatches = matchedResults
-            .Where(record =>
-                record is { IsSuccess: true, ApiResult.Result.IsHighConfidenceMatch: true }
-            )
-            .Select(MapSuccessfulMatchRecord)
-            .ToList();
+        var successfulMatches = new List<SuccessfulMatchRecord>();
+
+        var areMatchedSuccess = matchedResults.Where(record =>
+            record is { IsSuccess: true, ApiResult.Result.IsHighConfidenceMatch: true }
+        );
+
+        foreach (var matchedResult in areMatchedSuccess)
+        {
+            var successfulMatch = TryMapSuccessfulMatchRecord(sourceBlobName, matchedResult);
+
+            if (successfulMatch is not null)
+            {
+                successfulMatches.Add(successfulMatch);
+            }
+        }
 
         var csvContent = BuildCsv(successfulMatches);
         var destinationBlobName = BuildSuccessBlobName(sourceBlobName);
@@ -46,7 +57,8 @@ public sealed class SuccessMatchFileWriter(
         );
     }
 
-    private static SuccessfulMatchRecord MapSuccessfulMatchRecord(
+    private SuccessfulMatchRecord? TryMapSuccessfulMatchRecord(
+        string sourceBlobName,
         ProcessedMatchRecord<CsvRecordDto> matchedRecord
     )
     {
@@ -55,18 +67,28 @@ public sealed class SuccessMatchFileWriter(
             || string.IsNullOrWhiteSpace(id)
         )
         {
-            throw new InvalidOperationException(
-                $"Successful match record is missing required '{InputIdHeader}' field."
+            logger.LogWarning(
+                "Skipping successful match record from blob {SourceBlobName} because required field {FieldName} is missing.",
+                sourceBlobName,
+                InputIdHeader
             );
+
+            return null;
         }
 
         var nhsNumber = matchedRecord.ApiResult?.Result?.NhsNumber;
 
         if (string.IsNullOrWhiteSpace(nhsNumber))
         {
-            throw new InvalidOperationException(
-                $"Successful match record for '{id}' is missing NHS number."
+            logger.LogWarning(
+                "Skipping successful match record from blob {SourceBlobName} for {InputIdHeader} {Id} because required field {FieldName} is missing.",
+                sourceBlobName,
+                InputIdHeader,
+                id,
+                NhsNumberHeader
             );
+
+            return null;
         }
 
         return new SuccessfulMatchRecord(id, NhsNoType, nhsNumber);

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -1,5 +1,7 @@
 using System.Globalization;
 using System.Text;
+using CsvHelper;
+using CsvHelper.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using SUI.Client.Core.Application.Models;
@@ -107,35 +109,25 @@ public sealed class SuccessMatchFileWriter(
     private static string BuildCsv(IReadOnlyCollection<SuccessfulMatchRecord> records)
     {
         var builder = new StringBuilder();
-        builder.AppendLine($"{IdHeader},{TypeHeader},{NhsNumberHeader}");
+        using var textWriter = new StringWriter(builder, CultureInfo.InvariantCulture);
+        using var csvWriter = new CsvWriter(
+            textWriter,
+            new CsvConfiguration(CultureInfo.InvariantCulture) { NewLine = Environment.NewLine }
+        );
+
+        csvWriter.WriteField(IdHeader);
+        csvWriter.WriteField(TypeHeader);
+        csvWriter.WriteField(NhsNumberHeader);
+        csvWriter.NextRecord();
 
         foreach (var record in records)
         {
-            builder.AppendLine(
-                string.Join(
-                    ",",
-                    EscapeCsvValue(record.Id),
-                    EscapeCsvValue(record.Type),
-                    EscapeCsvValue(record.NhsNumber)
-                )
-            );
+            csvWriter.WriteField(record.Id);
+            csvWriter.WriteField(record.Type);
+            csvWriter.WriteField(record.NhsNumber);
+            csvWriter.NextRecord();
         }
 
         return builder.ToString();
-    }
-
-    private static string EscapeCsvValue(string value)
-    {
-        if (
-            value.Contains(',')
-            || value.Contains('"')
-            || value.Contains('\n')
-            || value.Contains('\r')
-        )
-        {
-            return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
-        }
-
-        return value;
     }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -33,8 +33,16 @@ public sealed class SuccessMatchFileWriter(
     {
         var successfulMatches = new List<SuccessfulMatchRecord>();
 
-        var areMatchedSuccess = matchedResults.Where(record =>
-            record is { IsSuccess: true, ApiResult.Result.IsHighConfidenceMatch: true }
+        var areMatchedSuccess = matchedResults
+            .Where(record =>
+                record is { IsSuccess: true, ApiResult.Result.IsHighConfidenceMatch: true }
+            )
+            .ToList();
+
+        logger.LogInformation(
+            "Found {SuccessfulMatchesCount} successful matches with high confidence in blob {SourceBlobName}.",
+            areMatchedSuccess.Count,
+            sourceBlobName
         );
 
         foreach (var matchedResult in areMatchedSuccess)
@@ -50,13 +58,17 @@ public sealed class SuccessMatchFileWriter(
         var csvContent = BuildCsv(successfulMatches);
         var destinationBlobName = BuildSuccessBlobName(sourceBlobName);
 
-        await blobStorageClient.UploadBlobAsync(
-            options.Value.SuccessContainerName,
-            destinationBlobName,
-            BinaryData.FromString(csvContent),
-            CsvContentType,
-            cancellationToken
-        );
+        // Upload a success file only if we have results
+        if (areMatchedSuccess.Count > 0)
+        {
+            await blobStorageClient.UploadBlobAsync(
+                options.Value.SuccessContainerName,
+                destinationBlobName,
+                BinaryData.FromString(csvContent),
+                CsvContentType,
+                cancellationToken
+            );
+        }
     }
 
     private SuccessfulMatchRecord? TryMapSuccessfulMatchRecord(

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -59,7 +59,7 @@ public sealed class SuccessMatchFileWriter(
         var destinationBlobName = BuildSuccessBlobName(sourceBlobName);
 
         // Upload a success file only if we have results
-        if (areMatchedSuccess.Count > 0)
+        if (successfulMatches.Count > 0)
         {
             await blobStorageClient.UploadBlobAsync(
                 options.Value.SuccessContainerName,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -7,6 +7,13 @@ using SUI.Client.StorageProcessJob.Application.Interfaces;
 
 namespace SUI.Client.StorageProcessJob.Application;
 
+/// <summary>
+/// Writer to filter out and write successful matches with a confident score
+/// to a new CSV file in blob storage.
+/// </summary>
+/// <param name="timeProvider"></param>
+/// <param name="blobStorageClient"></param>
+/// <param name="options"></param>
 public sealed class SuccessMatchFileWriter(
     TimeProvider timeProvider,
     IBlobStorageClient blobStorageClient,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessMatchFileWriter.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Options;
+using SUI.Client.Core.Application.Models;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
+using SUI.Client.StorageProcessJob.Application.Interfaces;
+
+namespace SUI.Client.StorageProcessJob.Application;
+
+public sealed class SuccessMatchFileWriter(
+    TimeProvider timeProvider,
+    IBlobStorageClient blobStorageClient,
+    IOptions<StorageProcessJobOptions> options
+) : ISuccessMatchFileWriter
+{
+    private const string IdHeader = "LLId";
+    private const string TypeHeader = "Type";
+    private const string NhsNumberHeader = "NhsNumber";
+    private const string InputIdHeader = "Id";
+    private const string NhsNoType = "NHSNo";
+    private const string CsvContentType = "text/csv";
+
+    public async Task WriteAsync(
+        string sourceBlobName,
+        IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
+        CancellationToken cancellationToken
+    )
+    {
+        var successfulMatches = matchedResults
+            .Where(record =>
+                record is { IsSuccess: true, ApiResult.Result.IsHighConfidenceMatch: true }
+            )
+            .Select(MapSuccessfulMatchRecord)
+            .ToList();
+
+        var csvContent = BuildCsv(successfulMatches);
+        var destinationBlobName = BuildSuccessBlobName(sourceBlobName);
+
+        await blobStorageClient.UploadBlobAsync(
+            options.Value.SuccessContainerName,
+            destinationBlobName,
+            BinaryData.FromString(csvContent),
+            CsvContentType,
+            cancellationToken
+        );
+    }
+
+    private static SuccessfulMatchRecord MapSuccessfulMatchRecord(
+        ProcessedMatchRecord<CsvRecordDto> matchedRecord
+    )
+    {
+        if (
+            !matchedRecord.OriginalData.Record.TryGetValue(InputIdHeader, out var id)
+            || string.IsNullOrWhiteSpace(id)
+        )
+        {
+            throw new InvalidOperationException(
+                $"Successful match record is missing required '{InputIdHeader}' field."
+            );
+        }
+
+        var nhsNumber = matchedRecord.ApiResult?.Result?.NhsNumber;
+
+        if (string.IsNullOrWhiteSpace(nhsNumber))
+        {
+            throw new InvalidOperationException(
+                $"Successful match record for '{id}' is missing NHS number."
+            );
+        }
+
+        return new SuccessfulMatchRecord(id, NhsNoType, nhsNumber);
+    }
+
+    private string BuildSuccessBlobName(string sourceBlobName)
+    {
+        var fileNameWithoutExtension = Path.GetFileNameWithoutExtension(sourceBlobName);
+        var timestamp = timeProvider
+            .GetUtcNow()
+            .ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+
+        return $"{timestamp}_{fileNameWithoutExtension}/{fileNameWithoutExtension}_success.csv";
+    }
+
+    private static string BuildCsv(IReadOnlyCollection<SuccessfulMatchRecord> records)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"{IdHeader},{TypeHeader},{NhsNumberHeader}");
+
+        foreach (var record in records)
+        {
+            builder.AppendLine(
+                string.Join(
+                    ",",
+                    EscapeCsvValue(record.Id),
+                    EscapeCsvValue(record.Type),
+                    EscapeCsvValue(record.NhsNumber)
+                )
+            );
+        }
+
+        return builder.ToString();
+    }
+
+    private static string EscapeCsvValue(string value)
+    {
+        if (
+            value.Contains(',')
+            || value.Contains('"')
+            || value.Contains('\n')
+            || value.Contains('\r')
+        )
+        {
+            return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+        }
+
+        return value;
+    }
+}

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessfulMatchRecord.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/SuccessfulMatchRecord.cs
@@ -1,0 +1,3 @@
+namespace SUI.Client.StorageProcessJob.Application;
+
+public sealed record SuccessfulMatchRecord(string Id, string Type, string NhsNumber);

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Infrastructure/Azure/AzureBlobStorageClient.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Infrastructure/Azure/AzureBlobStorageClient.cs
@@ -24,6 +24,32 @@ public sealed class AzureBlobStorageClient(BlobServiceClient blobServiceClient) 
         return response.Value.Content;
     }
 
+    public async Task UploadBlobAsync(
+        string destinationContainerName,
+        string destinationBlobName,
+        BinaryData content,
+        string contentType,
+        CancellationToken cancellationToken
+    )
+    {
+        var destinationContainerClient = blobServiceClient.GetBlobContainerClient(
+            destinationContainerName
+        );
+        await destinationContainerClient.CreateIfNotExistsAsync(
+            cancellationToken: cancellationToken
+        );
+
+        var destinationBlobClient = destinationContainerClient.GetBlobClient(destinationBlobName);
+        await destinationBlobClient.UploadAsync(
+            content,
+            new BlobUploadOptions
+            {
+                HttpHeaders = new BlobHttpHeaders { ContentType = contentType },
+            },
+            cancellationToken
+        );
+    }
+
     public async Task ArchiveProcessedAsync(
         StorageBlobMessage blobMessage,
         string destinationContainerName,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -64,6 +64,7 @@ builder.Services.AddSingleton<IBlobStorageClient, AzureBlobStorageClient>();
 builder.Services.AddSingleton<IStorageQueueClient, AzureStorageQueueClient>();
 builder.Services.AddSingleton<IStorageQueueMessageParser, EventGridMessageParser>();
 builder.Services.AddSingleton<IBlobFileOrchestrator, BlobFileOrchestrator>();
+builder.Services.AddSingleton<ISuccessMatchFileWriter, SuccessMatchFileWriter>();
 builder.Services.AddHttpClient<IMatchingApiClient, MatchingApiClient>(
     (serviceProvider, client) =>
     {

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/StorageProcessJobOptions.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/StorageProcessJobOptions.cs
@@ -10,6 +10,7 @@ public sealed class StorageProcessJobOptions
     public string QueueName { get; init; } = "storage-process-job";
 
     public string ProcessedContainerName { get; init; } = "processed";
+    public string SuccessContainerName { get; init; } = "success";
     public int MaxDequeueCount { get; init; } = 1;
     public int MessageVisibilityTimeoutMinutes { get; init; } = 10;
     public int MessageVisibilityRenewalIntervalMinutes { get; init; } = 5;

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -8,6 +8,7 @@
   "StorageProcessJob": {
     "QueueName": "storage-process-job",
     "ProcessedContainerName": "processed",
+    "SuccessContainerName": "success",
     "MaxDequeueCount": 1,
     "MessageVisibilityTimeoutMinutes": 10,
     "MessageVisibilityRenewalIntervalMinutes": 5,

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
@@ -14,6 +14,7 @@
   "StorageProcessJob": {
     "QueueName": "storage-process-job",
     "ProcessedContainerName": "processed",
+    "SuccessContainerName": "success",
     "MaxDequeueCount": 1,
     "MessageVisibilityTimeoutMinutes": 10,
     "MessageVisibilityRenewalIntervalMinutes": 5,

--- a/src/Shared/Constants/MatchScoreConstants.cs
+++ b/src/Shared/Constants/MatchScoreConstants.cs
@@ -1,0 +1,6 @@
+namespace Shared.Constants;
+
+public static class MatchScoreConstants
+{
+    public const decimal MatchSuccessThreshold = 0.95m;
+}

--- a/src/Shared/Models/MatchResult.cs
+++ b/src/Shared/Models/MatchResult.cs
@@ -1,4 +1,6 @@
-﻿namespace Shared.Models;
+﻿using Shared.Constants;
+
+namespace Shared.Models;
 
 public class MatchResult
 {
@@ -15,5 +17,6 @@ public class MatchResult
     public decimal? Score { get; set; }
 
     [JsonIgnore]
-    public bool IsHighConfidenceMatch => MatchStatus == MatchStatus.Match && Score is > 0.95m;
+    public bool IsHighConfidenceMatch =>
+        MatchStatus == MatchStatus.Match && Score is > MatchScoreConstants.MatchSuccessThreshold;
 }

--- a/src/Shared/Models/MatchResult.cs
+++ b/src/Shared/Models/MatchResult.cs
@@ -13,4 +13,7 @@ public class MatchResult
 
     [JsonPropertyName("score")]
     public decimal? Score { get; set; }
+
+    [JsonIgnore]
+    public bool IsHighConfidenceMatch => MatchStatus == MatchStatus.Match && Score is > 0.95m;
 }

--- a/src/Shared/Models/MatchResult.cs
+++ b/src/Shared/Models/MatchResult.cs
@@ -18,5 +18,5 @@ public class MatchResult
 
     [JsonIgnore]
     public bool IsHighConfidenceMatch =>
-        MatchStatus == MatchStatus.Match && Score is > MatchScoreConstants.MatchSuccessThreshold;
+        MatchStatus == MatchStatus.Match && Score is >= MatchScoreConstants.MatchSuccessThreshold;
 }

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/CsvHeaderValidatorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/CsvHeaderValidatorTests.cs
@@ -1,6 +1,6 @@
 using SUI.Client.Core.Infrastructure.CsvParsers;
 
-namespace Unit.Tests.StorageProcessFunction;
+namespace Unit.Tests.Client.CoreTests.InfrastructureTests;
 
 public class CsvHeaderValidatorTests
 {
@@ -8,7 +8,7 @@ public class CsvHeaderValidatorTests
     public void Should_NotThrow_When_HeadersArePresent()
     {
         var headers = new HashSet<string>(
-            ["GivenName", "FamilyName", "DOB", "Postcode"],
+            ["Id", "GivenName", "FamilyName", "DOB", "Postcode"],
             StringComparer.OrdinalIgnoreCase
         );
 
@@ -27,6 +27,7 @@ public class CsvHeaderValidatorTests
             CsvHeaderValidator.Validate(headers, CsvParserNameConstants.TypeOne)
         );
 
+        Assert.Contains("Id", exception.Message);
         Assert.Contains("Postcode", exception.Message);
     }
 

--- a/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
@@ -56,6 +56,8 @@ public class BlobFileOrchestratorTests
     public async Task Should_ProcessBlob_When_QueueMessageIsValid()
     {
         var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
+        IEnumerable<CsvRecordDto>? capturedRecords = null;
+
         _blobFileReader
             .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
             .ReturnsAsync(BinaryData.FromString(ValidBlobContent));
@@ -67,6 +69,9 @@ public class BlobFileOrchestratorTests
                     CancellationToken.None
                 )
             )
+            .Callback<IEnumerable<CsvRecordDto>, string, CancellationToken>(
+                (records, _, _) => capturedRecords = records.ToList()
+            )
             .ReturnsAsync(CreateMatchedResults());
 
         await _sut.ProcessAsync(queueMessage, CancellationToken.None);
@@ -75,17 +80,20 @@ public class BlobFileOrchestratorTests
             x => x.GetBlobContents(queueMessage, CancellationToken.None),
             Times.Once
         );
+
+        Assert.NotNull(capturedRecords);
+        var recordsList = capturedRecords.ToList();
+        var record = Assert.Single(recordsList);
+        Assert.Equal("1111", record.Record["Id"]);
+        Assert.Equal("Jane", record.Record["GivenName"]);
+        Assert.Equal("Doe", record.Record["FamilyName"]);
+        Assert.Equal("2012-05-10", record.Record["DOB"]);
+        Assert.Equal("SW1A 1AA", record.Record["Postcode"]);
+
         _blobPayloadProcessor.Verify(
             x =>
                 x.ProcessAsync(
-                    It.Is<IEnumerable<CsvRecordDto>>(records =>
-                        records.Count() == 1
-                        && records.First().Record["Id"] == "1111"
-                        && records.First().Record["GivenName"] == "Jane"
-                        && records.First().Record["FamilyName"] == "Doe"
-                        && records.First().Record["DOB"] == "2012-05-10"
-                        && records.First().Record["Postcode"] == "SW1A 1AA"
-                    ),
+                    It.IsAny<IEnumerable<CsvRecordDto>>(),
                     "test-file.csv",
                     CancellationToken.None
                 ),

--- a/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
@@ -240,7 +240,7 @@ public class BlobFileOrchestratorTests
             _sut.ProcessAsync(queueMessage, CancellationToken.None)
         );
 
-        Assert.Equal("CSV is missing required headers: Postcode.", exception.Message);
+        Assert.Equal("CSV is missing required headers: Id, Postcode.", exception.Message);
         _blobPayloadProcessor.Verify(
             x =>
                 x.ProcessAsync(

--- a/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
@@ -1,11 +1,11 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
-
 using Moq;
-
+using Shared.Models;
 using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
 using SUI.Client.StorageProcessJob;
 using SUI.Client.StorageProcessJob.Application;
@@ -15,14 +15,21 @@ namespace Unit.Tests.Client.StorageProcessJob;
 
 public class BlobFileOrchestratorTests
 {
+    private const string ValidBlobContent = """
+        Id,GivenName,FamilyName,DOB,Postcode
+        1111,Jane,Doe,2012-05-10,SW1A 1AA
+        """;
+
     private readonly Mock<IBlobStorageClient> _blobFileReader;
     private readonly Mock<IMatchPersonRecordOrchestrator<CsvRecordDto>> _blobPayloadProcessor;
+    private readonly Mock<ISuccessMatchFileWriter> _successMatchFileWriter;
     private readonly BlobFileOrchestrator _sut;
     private readonly FakeTimeProvider _timeProvider;
     private readonly IOptions<StorageProcessJobOptions> _options = Options.Create(
         new StorageProcessJobOptions
         {
             ProcessedContainerName = "processed",
+            SuccessContainerName = "success",
             CsvParserName = CsvParserNameConstants.TypeOne,
         }
     );
@@ -31,6 +38,7 @@ public class BlobFileOrchestratorTests
     {
         _blobFileReader = new Mock<IBlobStorageClient>();
         _blobPayloadProcessor = new Mock<IMatchPersonRecordOrchestrator<CsvRecordDto>>();
+        _successMatchFileWriter = new Mock<ISuccessMatchFileWriter>();
         _timeProvider = new FakeTimeProvider(
             new DateTimeOffset(2026, 1, 20, 12, 0, 0, TimeSpan.Zero)
         );
@@ -39,6 +47,7 @@ public class BlobFileOrchestratorTests
             _timeProvider,
             _blobFileReader.Object,
             _blobPayloadProcessor.Object,
+            _successMatchFileWriter.Object,
             _options
         );
     }
@@ -47,15 +56,9 @@ public class BlobFileOrchestratorTests
     public async Task Should_ProcessBlob_When_QueueMessageIsValid()
     {
         var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
-        var blobContent = BinaryData.FromString(
-            """
-            GivenName,FamilyName,DOB,Postcode
-            Jane,Doe,2012-05-10,SW1A 1AA
-            """
-        );
         _blobFileReader
             .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
-            .ReturnsAsync(blobContent);
+            .ReturnsAsync(BinaryData.FromString(ValidBlobContent));
         _blobPayloadProcessor
             .Setup(x =>
                 x.ProcessAsync(
@@ -64,7 +67,7 @@ public class BlobFileOrchestratorTests
                     CancellationToken.None
                 )
             )
-            .ReturnsAsync([]);
+            .ReturnsAsync(CreateMatchedResults());
 
         await _sut.ProcessAsync(queueMessage, CancellationToken.None);
 
@@ -77,6 +80,7 @@ public class BlobFileOrchestratorTests
                 x.ProcessAsync(
                     It.Is<IEnumerable<CsvRecordDto>>(records =>
                         records.Count() == 1
+                        && records.First().Record["Id"] == "1111"
                         && records.First().Record["GivenName"] == "Jane"
                         && records.First().Record["FamilyName"] == "Doe"
                         && records.First().Record["DOB"] == "2012-05-10"
@@ -101,6 +105,44 @@ public class BlobFileOrchestratorTests
     }
 
     [Fact]
+    public async Task Should_CallSuccessWriter_When_ThereAreSuccessfulMatches()
+    {
+        var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
+        _blobFileReader
+            .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
+            .ReturnsAsync(BinaryData.FromString(ValidBlobContent));
+        _blobPayloadProcessor
+            .Setup(x =>
+                x.ProcessAsync(
+                    It.IsAny<IEnumerable<CsvRecordDto>>(),
+                    "test-file.csv",
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(CreateMatchedResults());
+
+        await _sut.ProcessAsync(queueMessage, CancellationToken.None);
+
+        _blobFileReader.Verify(
+            x => x.GetBlobContents(queueMessage, CancellationToken.None),
+            Times.Once
+        );
+        _successMatchFileWriter.Verify(
+            x =>
+                x.WriteAsync(
+                    "test-file.csv",
+                    It.Is<IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>>>(records =>
+                        records.Count == 1
+                        && records.Single().OriginalData.Record["Id"] == "1111"
+                        && records.Single().ApiResult!.Result!.NhsNumber == "92938475748"
+                    ),
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
     public async Task Should_Throw_When_QueueMessageDoesNotContainContainerName()
     {
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -111,25 +153,7 @@ public class BlobFileOrchestratorTests
             x => x.GetBlobContents(It.IsAny<StorageBlobMessage>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
-        _blobPayloadProcessor.Verify(
-            x =>
-                x.ProcessAsync(
-                    It.IsAny<IEnumerable<CsvRecordDto>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Never
-        );
-        _blobFileReader.Verify(
-            x =>
-                x.ArchiveProcessedAsync(
-                    It.IsAny<StorageBlobMessage>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Never
-        );
+        VerifyNoProcessingSideEffects();
     }
 
     [Fact]
@@ -143,47 +167,25 @@ public class BlobFileOrchestratorTests
             x => x.GetBlobContents(It.IsAny<StorageBlobMessage>(), It.IsAny<CancellationToken>()),
             Times.Never
         );
-        _blobPayloadProcessor.Verify(
-            x =>
-                x.ProcessAsync(
-                    It.IsAny<IEnumerable<CsvRecordDto>>(),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Never
-        );
-        _blobFileReader.Verify(
-            x =>
-                x.ArchiveProcessedAsync(
-                    It.IsAny<StorageBlobMessage>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Never
-        );
+        VerifyNoProcessingSideEffects();
     }
 
     [Fact]
     public async Task Should_Throw_When_PersonSpecParserThrows()
     {
         var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
-        var blobContent = BinaryData.FromString(
-            """
-            GivenName,FamilyName,DOB,Postcode
-            Jane,Doe,2012-05-10,SW1A 1AA
-            """
-        );
         var failingOrchestrator = new Mock<IMatchPersonRecordOrchestrator<CsvRecordDto>>();
         var sut = new BlobFileOrchestrator(
             NullLogger<BlobFileOrchestrator>.Instance,
             _timeProvider,
             _blobFileReader.Object,
             failingOrchestrator.Object,
+            _successMatchFileWriter.Object,
             Options.Create(
                 new StorageProcessJobOptions
                 {
                     ProcessedContainerName = "processed",
+                    SuccessContainerName = "success",
                     CsvParserName = CsvParserNameConstants.TypeOne,
                 }
             )
@@ -191,7 +193,7 @@ public class BlobFileOrchestratorTests
 
         _blobFileReader
             .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
-            .ReturnsAsync(blobContent);
+            .ReturnsAsync(BinaryData.FromString(ValidBlobContent));
         failingOrchestrator
             .Setup(x =>
                 x.ProcessAsync(
@@ -216,16 +218,7 @@ public class BlobFileOrchestratorTests
                 ),
             Times.Never
         );
-        _blobFileReader.Verify(
-            x =>
-                x.ArchiveProcessedAsync(
-                    It.IsAny<StorageBlobMessage>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Never
-        );
+        VerifyNoProcessingSideEffects();
     }
 
     [Fact]
@@ -253,6 +246,109 @@ public class BlobFileOrchestratorTests
                 x.ProcessAsync(
                     It.IsAny<IEnumerable<CsvRecordDto>>(),
                     It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+        _successMatchFileWriter.Verify(
+            x =>
+                x.WriteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>>>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+        _blobFileReader.Verify(
+            x =>
+                x.ArchiveProcessedAsync(
+                    It.IsAny<StorageBlobMessage>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task Should_NotArchiveBlob_When_SuccessMatchWriterThrows()
+    {
+        var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
+        var matchedResults = CreateMatchedResults();
+
+        _blobFileReader
+            .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
+            .ReturnsAsync(BinaryData.FromString(ValidBlobContent));
+        _blobPayloadProcessor
+            .Setup(x =>
+                x.ProcessAsync(
+                    It.IsAny<IEnumerable<CsvRecordDto>>(),
+                    "test-file.csv",
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(matchedResults);
+        _successMatchFileWriter
+            .Setup(x => x.WriteAsync("test-file.csv", matchedResults, CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("Could not write success file."));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.ProcessAsync(queueMessage, CancellationToken.None)
+        );
+
+        Assert.Equal("Could not write success file.", exception.Message);
+        _blobFileReader.Verify(
+            x =>
+                x.ArchiveProcessedAsync(
+                    It.IsAny<StorageBlobMessage>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    private static List<ProcessedMatchRecord<CsvRecordDto>> CreateMatchedResults()
+    {
+        return
+        [
+            new()
+            {
+                OriginalData = new CsvRecordDto(
+                    new Dictionary<string, string> { ["Id"] = "1111", ["GivenName"] = "Jane" }
+                ),
+                IsSuccess = true,
+                ApiResult = new PersonMatchResponse
+                {
+                    Result = new MatchResult
+                    {
+                        MatchStatus = MatchStatus.Match,
+                        Score = 0.96m,
+                        NhsNumber = "92938475748",
+                    },
+                },
+            },
+        ];
+    }
+
+    private void VerifyNoProcessingSideEffects()
+    {
+        _blobPayloadProcessor.Verify(
+            x =>
+                x.ProcessAsync(
+                    It.IsAny<IEnumerable<CsvRecordDto>>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+        _successMatchFileWriter.Verify(
+            x =>
+                x.WriteAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>>>(),
                     It.IsAny<CancellationToken>()
                 ),
             Times.Never

--- a/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
@@ -88,7 +88,7 @@ public class SuccessMatchFileWriterTests
     {
         var matchedResults = new[]
         {
-            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.95m, "92938475748"),
+            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.949m, "92938475748"),
             CreateMatchedRecord("2222", true, MatchStatus.PotentialMatch, 0.99m, "92938475749"),
         };
 

--- a/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
@@ -13,7 +13,6 @@ namespace Unit.Tests.Client.StorageProcessJob;
 
 public class SuccessMatchFileWriterTests
 {
-    private static readonly string HeaderOnlyCsv = $"LL ID,Type,NhsNumber{Environment.NewLine}";
     private static readonly string SingleRowCsv =
         $"LL ID,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
     private static readonly string SingleRowWithSkippedRowsCsv =
@@ -66,30 +65,7 @@ public class SuccessMatchFileWriterTests
     }
 
     [Fact]
-    public async Task Should_ExcludeRecord_When_IsSuccessIsFalse()
-    {
-        var matchedResults = new[]
-        {
-            CreateMatchedRecord("1111", false, MatchStatus.Match, 0.99m, "92938475748"),
-        };
-
-        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
-
-        _blobStorageClient.Verify(
-            x =>
-                x.UploadBlobAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()
-                ),
-            Times.Once
-        );
-    }
-
-    [Fact]
-    public async Task Should_ExcludeRecord_When_MatchIsNotHighConfidence()
+    public async Task Should_NotUploadBlob_When_MatchIsNotHighConfidence()
     {
         var matchedResults = new[]
         {
@@ -104,16 +80,36 @@ public class SuccessMatchFileWriterTests
                 x.UploadBlobAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<BinaryData>(),
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()
                 ),
-            Times.Once
+            Times.Never
         );
     }
 
     [Fact]
-    public async Task Should_SkipRecordAndLogWarning_When_EligibleRecordIsMissingId()
+    public async Task Should_NotUploadBlob_When_NoRecordsProvided()
+    {
+        var matchedResults = Array.Empty<ProcessedMatchRecord<CsvRecordDto>>();
+
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<BinaryData>(),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Never
+        );
+    }
+
+    [Fact]
+    public async Task Should_NotUploadBlob_When_EligibleRecordIsMissingId()
     {
         var matchedResults = new[]
         {
@@ -127,18 +123,19 @@ public class SuccessMatchFileWriterTests
                 x.UploadBlobAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<BinaryData>(),
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()
                 ),
-            Times.Once
+            Times.Never
         );
 
         VerifyWarningLogged("test-file.csv", "Id");
     }
 
+    // Edge case
     [Fact]
-    public async Task Should_SkipRecordAndLogWarning_When_EligibleRecordIsMissingNhsNumber()
+    public async Task Should_NotUploadBlob_When_EligibleRecordIsMissingNhsNumber()
     {
         var matchedResults = new[]
         {
@@ -152,11 +149,11 @@ public class SuccessMatchFileWriterTests
                 x.UploadBlobAsync(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
-                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<BinaryData>(),
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()
                 ),
-            Times.Once
+            Times.Never
         );
 
         VerifyWarningLogged("test-file.csv", "NhsNumber");

--- a/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
@@ -1,0 +1,173 @@
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Shared.Models;
+using SUI.Client.Core.Application.Models;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
+using SUI.Client.StorageProcessJob;
+using SUI.Client.StorageProcessJob.Application;
+using SUI.Client.StorageProcessJob.Application.Interfaces;
+
+namespace Unit.Tests.Client.StorageProcessJob;
+
+public class SuccessMatchFileWriterTests
+{
+    private static readonly string HeaderOnlyCsv = $"LLId,Type,NhsNumber{Environment.NewLine}";
+    private static readonly string SingleRowCsv =
+        $"LLId,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
+
+    private readonly Mock<IBlobStorageClient> _blobStorageClient = new();
+    private readonly FakeTimeProvider _timeProvider = new(
+        new DateTimeOffset(2026, 1, 20, 12, 0, 0, TimeSpan.Zero)
+    );
+    private readonly ISuccessMatchFileWriter _sut;
+
+    public SuccessMatchFileWriterTests()
+    {
+        _sut = new SuccessMatchFileWriter(
+            _timeProvider,
+            _blobStorageClient.Object,
+            Options.Create(
+                new StorageProcessJobOptions
+                {
+                    CsvParserName = "TypeOne",
+                    SuccessContainerName = "success",
+                }
+            )
+        );
+    }
+
+    [Fact]
+    public async Task Should_WriteOneRow_When_RecordIsHighConfidenceMatch()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.96m, "92938475748"),
+        };
+
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    "success",
+                    "20260120120000_test-file/test-file_success.csv",
+                    It.Is<BinaryData>(data => data.ToString() == SingleRowCsv),
+                    "text/csv",
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task Should_ExcludeRecord_When_IsSuccessIsFalse()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord("1111", false, MatchStatus.Match, 0.99m, "92938475748"),
+        };
+
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task Should_ExcludeRecord_When_MatchIsNotHighConfidence()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.95m, "92938475748"),
+            CreateMatchedRecord("2222", true, MatchStatus.PotentialMatch, 0.99m, "92938475749"),
+        };
+
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task Should_Throw_When_EligibleRecordIsMissingId()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord(null, true, MatchStatus.Match, 0.96m, "92938475748"),
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None)
+        );
+
+        Assert.Equal("Successful match record is missing required 'Id' field.", exception.Message);
+    }
+
+    [Fact]
+    public async Task Should_Throw_When_EligibleRecordIsMissingNhsNumber()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.96m, null),
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None)
+        );
+
+        Assert.Equal(
+            "Successful match record for '1111' is missing NHS number.",
+            exception.Message
+        );
+    }
+
+    private static ProcessedMatchRecord<CsvRecordDto> CreateMatchedRecord(
+        string? id,
+        bool isSuccess,
+        MatchStatus matchStatus,
+        decimal? score,
+        string? nhsNumber
+    )
+    {
+        var record = new Dictionary<string, string>();
+
+        if (id is not null)
+        {
+            record["Id"] = id;
+        }
+
+        return new ProcessedMatchRecord<CsvRecordDto>
+        {
+            OriginalData = new CsvRecordDto(record),
+            IsSuccess = isSuccess,
+            ApiResult = new PersonMatchResponse
+            {
+                Result = new MatchResult
+                {
+                    MatchStatus = matchStatus,
+                    Score = score,
+                    NhsNumber = nhsNumber,
+                },
+            },
+        };
+    }
+}

--- a/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
@@ -15,8 +16,11 @@ public class SuccessMatchFileWriterTests
     private static readonly string HeaderOnlyCsv = $"LL ID,Type,NhsNumber{Environment.NewLine}";
     private static readonly string SingleRowCsv =
         $"LL ID,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
+    private static readonly string SingleRowWithSkippedRowsCsv =
+        $"LL ID,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
 
     private readonly Mock<IBlobStorageClient> _blobStorageClient = new();
+    private readonly Mock<ILogger<SuccessMatchFileWriter>> _logger = new();
     private readonly FakeTimeProvider _timeProvider = new(
         new DateTimeOffset(2026, 1, 20, 12, 0, 0, TimeSpan.Zero)
     );
@@ -26,6 +30,7 @@ public class SuccessMatchFileWriterTests
     {
         _sut = new SuccessMatchFileWriter(
             _timeProvider,
+            _logger.Object,
             _blobStorageClient.Object,
             Options.Create(
                 new StorageProcessJobOptions
@@ -108,36 +113,81 @@ public class SuccessMatchFileWriterTests
     }
 
     [Fact]
-    public async Task Should_Throw_When_EligibleRecordIsMissingId()
+    public async Task Should_SkipRecordAndLogWarning_When_EligibleRecordIsMissingId()
     {
         var matchedResults = new[]
         {
             CreateMatchedRecord(null, true, MatchStatus.Match, 0.96m, "92938475748"),
         };
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None)
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
         );
 
-        Assert.Equal("Successful match record is missing required 'Id' field.", exception.Message);
+        VerifyWarningLogged("test-file.csv", "Id");
     }
 
     [Fact]
-    public async Task Should_Throw_When_EligibleRecordIsMissingNhsNumber()
+    public async Task Should_SkipRecordAndLogWarning_When_EligibleRecordIsMissingNhsNumber()
     {
         var matchedResults = new[]
         {
             CreateMatchedRecord("1111", true, MatchStatus.Match, 0.96m, null),
         };
 
-        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None)
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.Is<BinaryData>(data => data.ToString() == HeaderOnlyCsv),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()
+                ),
+            Times.Once
         );
 
-        Assert.Equal(
-            "Successful match record for '1111' is missing NHS number.",
-            exception.Message
+        VerifyWarningLogged("test-file.csv", "NhsNumber");
+    }
+
+    [Fact]
+    public async Task Should_WriteOnlyValidRows_When_EligibleRowsHaveMissingFields()
+    {
+        var matchedResults = new[]
+        {
+            CreateMatchedRecord("1111", true, MatchStatus.Match, 0.96m, "92938475748"),
+            CreateMatchedRecord(null, true, MatchStatus.Match, 0.96m, "92938475749"),
+            CreateMatchedRecord("3333", true, MatchStatus.Match, 0.96m, null),
+        };
+
+        await _sut.WriteAsync("test-file.csv", matchedResults, CancellationToken.None);
+
+        _blobStorageClient.Verify(
+            x =>
+                x.UploadBlobAsync(
+                    "success",
+                    "20260120120000_test-file/test-file_success.csv",
+                    It.Is<BinaryData>(data => data.ToString() == SingleRowWithSkippedRowsCsv),
+                    "text/csv",
+                    CancellationToken.None
+                ),
+            Times.Once
         );
+
+        VerifyWarningLogged("test-file.csv", "Id");
+        VerifyWarningLogged("test-file.csv", "NhsNumber");
     }
 
     private static ProcessedMatchRecord<CsvRecordDto> CreateMatchedRecord(
@@ -169,5 +219,24 @@ public class SuccessMatchFileWriterTests
                 },
             },
         };
+    }
+
+    private void VerifyWarningLogged(string sourceBlobName, string fieldName)
+    {
+        _logger.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (state, _) =>
+                            state.ToString()!.Contains(sourceBlobName, StringComparison.Ordinal)
+                            && state.ToString()!.Contains(fieldName, StringComparison.Ordinal)
+                    ),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.AtLeastOnce
+        );
     }
 }

--- a/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/SuccessMatchFileWriterTests.cs
@@ -12,9 +12,9 @@ namespace Unit.Tests.Client.StorageProcessJob;
 
 public class SuccessMatchFileWriterTests
 {
-    private static readonly string HeaderOnlyCsv = $"LLId,Type,NhsNumber{Environment.NewLine}";
+    private static readonly string HeaderOnlyCsv = $"LL ID,Type,NhsNumber{Environment.NewLine}";
     private static readonly string SingleRowCsv =
-        $"LLId,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
+        $"LL ID,Type,NhsNumber{Environment.NewLine}1111,NHSNo,92938475748{Environment.NewLine}";
 
     private readonly Mock<IBlobStorageClient> _blobStorageClient = new();
     private readonly FakeTimeProvider _timeProvider = new(

--- a/tests/Unit.Tests/Shared/Models/MatchResultTests.cs
+++ b/tests/Unit.Tests/Shared/Models/MatchResultTests.cs
@@ -1,0 +1,46 @@
+using Shared.Models;
+
+namespace Unit.Tests.Shared.Models;
+
+public class MatchResultTests
+{
+    [Fact]
+    public void Should_ReturnTrue_When_StatusIsMatchAndScoreIsAboveThreshold()
+    {
+        var sut = new MatchResult { MatchStatus = MatchStatus.Match, Score = 0.96m };
+
+        Assert.True(sut.IsHighConfidenceMatch);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_ScoreIsExactlyThreshold()
+    {
+        var sut = new MatchResult { MatchStatus = MatchStatus.Match, Score = 0.95m };
+
+        Assert.False(sut.IsHighConfidenceMatch);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_ScoreIsBelowThreshold()
+    {
+        var sut = new MatchResult { MatchStatus = MatchStatus.Match, Score = 0.94m };
+
+        Assert.False(sut.IsHighConfidenceMatch);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_StatusIsNotMatch()
+    {
+        var sut = new MatchResult { MatchStatus = MatchStatus.PotentialMatch, Score = 0.99m };
+
+        Assert.False(sut.IsHighConfidenceMatch);
+    }
+
+    [Fact]
+    public void Should_ReturnFalse_When_ScoreIsNull()
+    {
+        var sut = new MatchResult { MatchStatus = MatchStatus.Match, Score = null };
+
+        Assert.False(sut.IsHighConfidenceMatch);
+    }
+}

--- a/tests/Unit.Tests/SharedTests/ModelTests/MatchResultTests.cs
+++ b/tests/Unit.Tests/SharedTests/ModelTests/MatchResultTests.cs
@@ -1,6 +1,6 @@
 using Shared.Models;
 
-namespace Unit.Tests.Shared.Models;
+namespace Unit.Tests.SharedTests.ModelTests;
 
 public class MatchResultTests
 {

--- a/tests/Unit.Tests/SharedTests/ModelTests/MatchResultTests.cs
+++ b/tests/Unit.Tests/SharedTests/ModelTests/MatchResultTests.cs
@@ -13,11 +13,11 @@ public class MatchResultTests
     }
 
     [Fact]
-    public void Should_ReturnFalse_When_ScoreIsExactlyThreshold()
+    public void Should_ReturnTrue_When_ScoreIsExactlyThreshold()
     {
         var sut = new MatchResult { MatchStatus = MatchStatus.Match, Score = 0.95m };
 
-        Assert.False(sut.IsHighConfidenceMatch);
+        Assert.True(sut.IsHighConfidenceMatch);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Changes in this PR are to take the successfully matched results and write them to a CSV in a successful directory.

## Changes

- SuccessfulMatchRecord
- SuccessMatchFileWriter - main method that takes results, selects successful ones and sends to blob writer.
- UploadBlobAsync - Generic method to write to blob
- StorageProcessJobOptions and config - to add the success directory name

## Validation

- UInit tested.
- Manually run with real CSV file.

## Notes:

- No idempotency in file writing as we specifically do not allow retries on app level errors. We can re-visit this later if we decide to change
- **CSV headers are subject to change once we know what they will look like. Additionally there may be a PR soon to remove these hard coded headers and use configuration values instead.**
- any missing CSV headers are treated as a file level failure and nothing is processed. 
