### PR TITLE
chore: remove devfeed and source

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -3,10 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add
-      key="azure-sdk-devfeed"
-      value="https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
-    />
   </packageSources>
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
@@ -15,9 +11,6 @@
     <clear />
     <packageSource key="nuget.org">
       <package pattern="*" />
-    </packageSource>
-    <packageSource key="azure-sdk-devfeed">
-      <package pattern="Azure.*" />
     </packageSource>
   </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
## Summary

Remove the azure sdk devfeed from Nuget.config. This is legacy and no longer needed for anything we use now

## Changes

- Removed the azure sdk devfeed and source from Nuget.config

## Validation

- Build works with no errors
- Restore works with no errors
- Run for a few days locally and no issues.
