### PR TITLE
feat: SUI-1698 - add blob-event-processor stack foundation

### DIFF
--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -1,0 +1,91 @@
+name: Deploy Blob-Event-Processor Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: The environment target for deployment
+        required: true
+        default: 'Integration'
+      what_if:
+        description: Run bicep what-if to check for changes
+        default: true
+        type: boolean
+      version:
+        description: Deployment version, tag, branch, or SHA to deploy
+        required: true
+        type: string
+      environment_prefix:
+        description: The prefix for the environment
+        default: 's215d01'
+        type: string
+      turn_on_alerts:
+        description: Enable monitoring alerts
+        default: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AZURE_ENV_NAME: ${{ inputs.environment }}
+      AZURE_ENV_PREFIX: ${{ inputs.environment_prefix }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
+      STACK_VERSION: ${{ inputs.version }}
+      AZURE_MONITORING_ACTION_GROUP_EMAIL: ${{ secrets.AZURE_MONITORING_ACTION_GROUP_EMAIL }}
+      AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER: ${{ vars.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
+      AZURE_CONTAINER_APP_VNET: ${{ secrets.AZURE_CONTAINER_APP_VNET }}
+      AZURE_CONTAINER_APP_ENV_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_ENV_SUBNET }}
+      AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.STACK_VERSION }}
+
+      - name: Ensure Azure CLI is installed
+        run: |
+          if ! command -v az &> /dev/null; then
+            curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          fi
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Run Bicep What-If
+        if: ${{ inputs.what_if == true }}
+        uses: Azure/deployment-what-if-action@v1.0.0
+        with:
+          subscription: ${{ env.AZURE_SUBSCRIPTION_ID }}
+          resourceGroup: ${{ env.AZURE_RESOURCE_GROUP }}
+          templateFile: infra/stacks/blob-event-processor/main.bicep
+          additionalParameters: environmentName="${{ env.AZURE_ENV_NAME }}" environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" location="${{ env.AZURE_LOCATION }}" monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" turnOnAlerts="${{ env.AZURE_TURN_ON_ALERTS }}"
+
+      - name: Deploy blob-event-processor infrastructure
+        if: ${{ inputs.what_if == false }}
+        run: |
+          az deployment group create \
+            --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
+            --subscription "${{ env.AZURE_SUBSCRIPTION_ID }}" \
+            --template-file infra/stacks/blob-event-processor/main.bicep \
+            --parameters environmentName="${{ env.AZURE_ENV_NAME }}" \
+              environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" \
+              location="${{ env.AZURE_LOCATION }}" \
+              monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" \
+              containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" \
+              containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" \
+              containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" \
+              turnOnAlerts="${{ env.AZURE_TURN_ON_ALERTS }}"

--- a/documentation/docs/design/infra-stack-segregation.md
+++ b/documentation/docs/design/infra-stack-segregation.md
@@ -100,8 +100,10 @@ Represents the next blob-triggered event processing deployment shape:
 
 - any shared Azure resources required by this architecture
 - blob storage and event-driven processing path
-- eventing and function-hosted processing resources as required by that model
+- eventing and ACA Job-hosted processing resources as required by that model
 - network/security resources needed for that environment
+
+The first implemented slice of this stack is the shared-platform and storage foundation. Event Grid wiring and processing-job deployment remain follow-up work.
 
 This stack must not depend on the client-agent infrastructure.
 
@@ -185,7 +187,7 @@ The recommended order of work is:
 
 1. extract shared modules from the current Bicep
 2. recreate the current deployment path behind an explicit `client-agent` stack root
-3. introduce the next `blob-event-processor` stack root and skeleton
+3. introduce the next `blob-event-processor` stack root and initial deployable foundation
 4. define the future `api-batch-processor` stack contract and skeleton
 5. update deployment documentation once the new structure is stable
 
@@ -229,7 +231,7 @@ The following items remain follow-up work outside the first restructure:
 
 - whether deployment IaC should later move into a private infra repo
 - whether any later CI/CD changes should accompany the new stack structure
-- the exact minimum first deployable slice for the next `blob-event-processor` application resources, where that belongs in separate implementation tickets
+- the Event Grid and ACA Job deployment work needed to complete the next `blob-event-processor` application slice, and where that belongs in separate implementation tickets
 - the exact boundary between automatable networking/security resources and LA-owned manual steps in each tenant
 
 ---

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,7 +5,7 @@ The deployable infrastructure roots now live under `infra/stacks`.
 Current structure:
 
 - `client-agent`: the full DfE-hosted test architecture, composed from shared modules and client-agent-specific resources
-- `blob-event-processor`: placeholder isolated stack root for the next event-driven architecture
+- `blob-event-processor`: initial deployable event-driven stack foundation, composed from shared modules plus blob/queue storage resources
 - `api-batch-processor`: placeholder isolated stack root for the future batch-oriented architecture
 
 Shared Bicep modules live under `infra/modules`.
@@ -21,6 +21,7 @@ CI/CD:
 - `.github/workflows/gh-deploy-infra.yml` remains the existing `src/app-host/infra` infrastructure workflow and still drives the current `azd provision` path
 - `.github/workflows/gh-client-infra-deploy.yml` deploys the legacy dedicated client-infrastructure path under `src/SUI.Client/SUI.Client.Watcher/infra`
 - `.github/workflows/gh-client-agent-infra-deploy.yml` deploys the full `client-agent` stack root
-- The placeholder stacks do not have runnable deployment workflows yet; those should be added when their stack roots become deployable
+- `blob-event-processor` does not have a dedicated deployment workflow yet; it is currently a manually deployable stack root
+- The placeholder/future stacks should gain dedicated workflows when their stack roots become deployable
 
 The intent is that stack roots define environment topology, while application deployment consumes outputs from the selected stack.

--- a/infra/README.md
+++ b/infra/README.md
@@ -21,7 +21,7 @@ CI/CD:
 - `.github/workflows/gh-deploy-infra.yml` remains the existing `src/app-host/infra` infrastructure workflow and still drives the current `azd provision` path
 - `.github/workflows/gh-client-infra-deploy.yml` deploys the legacy dedicated client-infrastructure path under `src/SUI.Client/SUI.Client.Watcher/infra`
 - `.github/workflows/gh-client-agent-infra-deploy.yml` deploys the full `client-agent` stack root
-- `blob-event-processor` does not have a dedicated deployment workflow yet; it is currently a manually deployable stack root
+- `.github/workflows/gh-blob-event-processor-infra-deploy.yml` deploys the `blob-event-processor` stack root
 - The placeholder/future stacks should gain dedicated workflows when their stack roots become deployable
 
 The intent is that stack roots define environment topology, while application deployment consumes outputs from the selected stack.

--- a/infra/modules/blob-event-processor/storage.bicep
+++ b/infra/modules/blob-event-processor/storage.bicep
@@ -1,0 +1,80 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var incomingContainerName = 'incoming'
+var processedContainerName = 'processed'
+var successContainerName = 'success'
+var queueName = 'storage-process-job'
+var poisonQueueName = '${queueName}-poison'
+var storageAccountName = toLower('${take(environmentPrefix, 8)}${take(lowercaseEnvironmentName, 8)}bep${take(uniqueString(resourceGroup().id, environmentPrefix, lowercaseEnvironmentName), 5)}')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  tags: tags
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Enabled'
+    supportsHttpsTrafficOnly: true
+  }
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = [
+  for containerName in [
+    incomingContainerName
+    processedContainerName
+    successContainerName
+  ]: {
+    parent: blobService
+    name: containerName
+    properties: {
+      publicAccess: 'None'
+    }
+  }
+]
+
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = [
+  for currentQueueName in [
+    queueName
+    poisonQueueName
+  ]: {
+    parent: queueService
+    name: currentQueueName
+  }
+]
+
+output accountName string = storageAccount.name
+output accountId string = storageAccount.id
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue
+output incomingContainerName string = incomingContainerName
+output processedContainerName string = processedContainerName
+output successContainerName string = successContainerName
+output queueName string = queueName
+output poisonQueueName string = poisonQueueName

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -1,5 +1,14 @@
 # Blob-Event-Processor Stack
 
-This is the placeholder root for the next isolated deployment architecture.
+This stack is the deployable foundation for the event-driven processing architecture.
 
-It exists to reserve the stack boundary and deployment contract without introducing any dependency on `client-agent`. Follow-up work should add the eventing, storage, function-hosted processing, and any required networking/security resources directly to this stack.
+It composes the shared platform modules directly and adds the initial blob/queue storage resources needed by the storage-driven processing path.
+
+Current scope:
+
+- shared platform resources for this stack
+- storage account
+- blob containers for incoming, processed, and success files
+- primary and poison storage queues for the processing job contract
+
+Follow-up work should add the Event Grid wiring, ACA Job deployment path, and any further networking/security resources directly to this stack without introducing any dependency on `client-agent`.

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -1,26 +1,143 @@
 targetScope = 'resourceGroup'
 
 @minLength(1)
-@description('The name of the deployment environment')
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
 param environmentName string
 
 @minLength(1)
 @description('The prefix used for all deployed resources')
 param environmentPrefix string
 
+@minLength(1)
+@description('The version number of the container app managed environment, used for naming convention')
+param containerAppManagedEnvironmentNumber string
+
+@minLength(1)
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@minLength(1)
+@description('Container App environment subnet')
+param containerAppEnvSubnet string
+
+@minLength(1)
 @description('The location used for all deployed resources')
-param location string = resourceGroup().location
+param location string
+
+@minLength(1)
+@description('The email address to be used for monitoring alerts')
+param monitoringActionGroupEmail string
+
+@description('Turn on monitoring alerts')
+param turnOnAlerts bool = false
+
+var lowercaseEnvironmentName = toLower(environmentName)
 
 var tags = {
+  'azd-env-name': environmentName
   Product: 'SUI'
   Environment: environmentName
   EnvironmentPrefix: environmentPrefix
   'Service Offering': 'SUI'
-  Stack: 'blob-event-processor'
 }
 
-// Placeholder stack root. Architecture-specific resources will be added in follow-up tickets.
+module identity '../../modules/shared/identity.bicep' = {
+  name: 'identity'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
+  }
+}
+
+module containerRegistry '../../modules/shared/container-registry.bicep' = {
+  name: 'container-registry'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
+  }
+}
+
+module observability '../../modules/shared/observability.bicep' = {
+  name: 'observability'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
+  }
+}
+
+module containerAppEnvironment '../../modules/shared/container-app-environment.bicep' = {
+  name: 'container-app-environment'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
+    containerAppVnet: containerAppVnet
+    containerAppEnvSubnet: containerAppEnvSubnet
+    tags: tags
+    logAnalyticsWorkspaceName: observability.outputs.workspaceName
+  }
+}
+
+module secrets '../../modules/shared/secrets.bicep' = {
+  name: 'secrets'
+  params: {
+    location: location
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+  }
+}
+
+module monitoring '../../modules/shared/monitoring.bicep' = {
+  name: 'monitoring'
+  params: {
+    location: location
+    turnOnAlerts: turnOnAlerts
+    logAnalyticsWorkspaceId: observability.outputs.workspaceId
+    actionGroupEmail: monitoringActionGroupEmail
+  }
+}
+
+module storage '../../modules/blob-event-processor/storage.bicep' = {
+  name: 'blob-event-processor-storage'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    tags: tags
+  }
+}
+
 output STACK_NAME string = 'blob-event-processor'
-output STACK_CONTRACT_STATUS string = 'placeholder'
 output LOCATION string = location
 output TAGS object = tags
+output MANAGED_IDENTITY_CLIENT_ID string = identity.outputs.clientId
+output MANAGED_IDENTITY_NAME string = identity.outputs.name
+output MANAGED_IDENTITY_PRINCIPAL_ID string = identity.outputs.principalId
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = observability.outputs.workspaceName
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = observability.outputs.workspaceId
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.outputs.endpoint
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = identity.outputs.id
+output AZURE_CONTAINER_REGISTRY_NAME string = containerRegistry.outputs.name
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = containerAppEnvironment.outputs.name
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = containerAppEnvironment.outputs.id
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvironment.outputs.defaultDomain
+output APPLICATION_INSIGHTS_CONNECTION_STRING string = observability.outputs.applicationInsightsConnectionString
+output SECRETS_VAULTURI string = secrets.outputs.vaultUri
+output SECRETS_VAULT_NAME string = secrets.outputs.name
+output STORAGE_ACCOUNT_NAME string = storage.outputs.accountName
+output STORAGE_ACCOUNT_ID string = storage.outputs.accountId
+output STORAGE_BLOB_ENDPOINT string = storage.outputs.blobEndpoint
+output STORAGE_QUEUE_ENDPOINT string = storage.outputs.queueEndpoint
+output STORAGE_INCOMING_CONTAINER_NAME string = storage.outputs.incomingContainerName
+output STORAGE_PROCESSED_CONTAINER_NAME string = storage.outputs.processedContainerName
+output STORAGE_SUCCESS_CONTAINER_NAME string = storage.outputs.successContainerName
+output STORAGE_QUEUE_NAME string = storage.outputs.queueName
+output STORAGE_POISON_QUEUE_NAME string = storage.outputs.poisonQueueName


### PR DESCRIPTION
## Summary

Introduce the initial `blob-event-processor` stack foundation so the blob-event-processor architecture has a real deployable IaC root to build on.

This PR establishes the stack boundary, provisions the shared platform plus storage resources needed for the processing flow, and adds a manual workflow so the stack can be tested independently. It does not yet complete the Event Grid or ACA Job runtime wiring.

## Changes

- replace the `blob-event-processor` placeholder root with a real stack root that composes the shared identity, ACR, observability, ACA environment, secrets, and monitoring modules
- add a stack-specific storage module that provisions the storage account, `incoming` / `processed` / `success` blob containers, and the primary plus poison storage queues for the processing contract
- expose stack outputs for the shared platform and storage resources so follow-on deployment work can consume them
- add a manual GitHub Actions workflow to run what-if or deploy the `blob-event-processor` stack root directly
- update the infra/design documentation so it reflects the new stack boundary and the fact that this PR delivers the deployable foundation rather than the full runtime path

## Validation

- `az bicep build --file infra/stacks/blob-event-processor/main.bicep`
- workflow YAML parsed successfully for `.github/workflows/gh-blob-event-processor-infra-deploy.yml`

## Follow-Up Context

This PR intentionally stops at the stack foundation. Event Grid wiring, ACA Job deployment of `SUI.Client.StorageProcessJob`, and any further networking/security hardening remain follow-up work.
