### PR TITLE
fix: SUI-1709 - change Azure Firewall and policy tiers to Basic

### DIFF
--- a/infra/modules/client-agent/infrastructure.bicep
+++ b/infra/modules/client-agent/infrastructure.bicep
@@ -219,6 +219,9 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2022-01-01' = {
   location: location
   tags: tags
   properties: {
+    sku: {
+      tier: 'Basic'
+    }
     threatIntelMode: 'Alert'
   }
 }
@@ -230,7 +233,7 @@ resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
   properties: {
     sku: {
       name: 'AZFW_VNet'
-      tier: 'Standard'
+      tier: 'Basic'
     }
     threatIntelMode: 'Alert'
     firewallPolicy: {

--- a/src/SUI.Client/SUI.Client.Watcher/infra/client.bicep
+++ b/src/SUI.Client/SUI.Client.Watcher/infra/client.bicep
@@ -199,6 +199,9 @@ resource firewallPolicy 'Microsoft.Network/firewallPolicies@2022-01-01' = {
   location: location
   tags: paramTags
   properties: {
+    sku: {
+      tier: 'Basic'
+    }
     threatIntelMode: 'Alert'
   }
 }
@@ -210,7 +213,7 @@ resource azureFirewallsVnetfwFirewallNameResource 'Microsoft.Network/azureFirewa
   properties: {
     sku: {
       name: 'AZFW_VNet'
-      tier: 'Standard'
+      tier: 'Basic'
     }
     threatIntelMode: 'Alert'
     firewallPolicy: {


### PR DESCRIPTION
## Summary

Changes the client-agent Azure Firewall deployment from `Standard` to `Basic` to reduce infrastructure cost where the higher tier is not required.

The PR also makes the firewall policy tier explicit so the policy and firewall remain aligned rather than relying on Azure defaults.

## Changes

- set the Azure Firewall tier to `Basic` in the shared client-agent infrastructure module
- set the Azure Firewall tier to `Basic` in the watcher client infrastructure definition
- add an explicit firewall policy `sku.tier` of `Basic` in both templates to keep policy and firewall configuration aligned

## Validation

- reviewed the ARM/Bicep schema for `Microsoft.Network/azureFirewalls` and `Microsoft.Network/firewallPolicies` to confirm `Basic` is a supported tier
- local `az bicep build` validation
