### PR TITLE
feat: SUI-1712 - add stack-owned resource group wrappers

### DIFF
--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -38,7 +38,6 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
-      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
       STACK_VERSION: ${{ inputs.version }}
       AZURE_MONITORING_ACTION_GROUP_EMAIL: ${{ secrets.AZURE_MONITORING_ACTION_GROUP_EMAIL }}
       AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER: ${{ vars.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
@@ -67,25 +66,40 @@ jobs:
 
       - name: Run Bicep What-If
         if: ${{ inputs.what_if == true }}
-        uses: Azure/deployment-what-if-action@v1.0.0
-        with:
-          subscription: ${{ env.AZURE_SUBSCRIPTION_ID }}
-          resourceGroup: ${{ env.AZURE_RESOURCE_GROUP }}
-          templateFile: infra/stacks/blob-event-processor/main.bicep
-          additionalParameters: environmentName="${{ env.AZURE_ENV_NAME }}" environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" location="${{ env.AZURE_LOCATION }}" monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" turnOnAlerts="${{ env.AZURE_TURN_ON_ALERTS }}"
+        run: |
+          STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-blob-event-processor"
+          echo "Target stack resource group: ${STACK_RESOURCE_GROUP}"
+
+          az deployment sub what-if \
+            --name "${STACK_RESOURCE_GROUP}-what-if" \
+            --location "${AZURE_LOCATION}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --template-file infra/stacks/blob-event-processor/subscription.bicep \
+            --parameters environmentName="${AZURE_ENV_NAME}" \
+              environmentPrefix="${AZURE_ENV_PREFIX}" \
+              location="${AZURE_LOCATION}" \
+              monitoringActionGroupEmail="${AZURE_MONITORING_ACTION_GROUP_EMAIL}" \
+              containerAppManagedEnvironmentNumber="${AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER}" \
+              containerAppVnet="${AZURE_CONTAINER_APP_VNET}" \
+              containerAppEnvSubnet="${AZURE_CONTAINER_APP_ENV_SUBNET}" \
+              turnOnAlerts="${AZURE_TURN_ON_ALERTS}"
 
       - name: Deploy blob-event-processor infrastructure
         if: ${{ inputs.what_if == false }}
         run: |
-          az deployment group create \
-            --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-            --subscription "${{ env.AZURE_SUBSCRIPTION_ID }}" \
-            --template-file infra/stacks/blob-event-processor/main.bicep \
-            --parameters environmentName="${{ env.AZURE_ENV_NAME }}" \
-              environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" \
-              location="${{ env.AZURE_LOCATION }}" \
-              monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" \
-              containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" \
-              containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" \
-              containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" \
-              turnOnAlerts="${{ env.AZURE_TURN_ON_ALERTS }}"
+          STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-blob-event-processor"
+          echo "Target stack resource group: ${STACK_RESOURCE_GROUP}"
+
+          az deployment sub create \
+            --name "${STACK_RESOURCE_GROUP}-deploy" \
+            --location "${AZURE_LOCATION}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --template-file infra/stacks/blob-event-processor/subscription.bicep \
+            --parameters environmentName="${AZURE_ENV_NAME}" \
+              environmentPrefix="${AZURE_ENV_PREFIX}" \
+              location="${AZURE_LOCATION}" \
+              monitoringActionGroupEmail="${AZURE_MONITORING_ACTION_GROUP_EMAIL}" \
+              containerAppManagedEnvironmentNumber="${AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER}" \
+              containerAppVnet="${AZURE_CONTAINER_APP_VNET}" \
+              containerAppEnvSubnet="${AZURE_CONTAINER_APP_ENV_SUBNET}" \
+              turnOnAlerts="${AZURE_TURN_ON_ALERTS}"

--- a/.github/workflows/gh-client-agent-infra-deploy.yml
+++ b/.github/workflows/gh-client-agent-infra-deploy.yml
@@ -34,7 +34,6 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
-      AZURE_RESOURCE_GROUP: ${{ secrets.AZURE_RESOURCE_GROUP }}
       STACK_VERSION: ${{ inputs.version }}
       AZURE_MONITORING_ACTION_GROUP_EMAIL: ${{ secrets.AZURE_MONITORING_ACTION_GROUP_EMAIL }}
       AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER: ${{ vars.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
@@ -64,26 +63,42 @@ jobs:
 
       - name: Run Bicep What-If
         if: ${{ inputs.what_if == true }}
-        uses: Azure/deployment-what-if-action@v1.0.0
-        with:
-          subscription: ${{ env.AZURE_SUBSCRIPTION_ID }}
-          resourceGroup: ${{ secrets.AZURE_RESOURCE_GROUP }}
-          templateFile: infra/stacks/client-agent/main.bicep
-          additionalParameters: environmentName="${{ env.AZURE_ENV_NAME }}" environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" location="${{ env.AZURE_LOCATION }}" monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" adminUsername="${{ env.VM_USERNAME }}" adminPassword="${{ env.VM_PASSWORD }}"
+        run: |
+          STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-client-agent"
+          echo "Target stack resource group: ${STACK_RESOURCE_GROUP}"
+
+          az deployment sub what-if \
+            --name "${STACK_RESOURCE_GROUP}-what-if" \
+            --location "${AZURE_LOCATION}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --template-file infra/stacks/client-agent/subscription.bicep \
+            --parameters environmentName="${AZURE_ENV_NAME}" \
+              environmentPrefix="${AZURE_ENV_PREFIX}" \
+              location="${AZURE_LOCATION}" \
+              monitoringActionGroupEmail="${AZURE_MONITORING_ACTION_GROUP_EMAIL}" \
+              containerAppManagedEnvironmentNumber="${AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER}" \
+              containerAppVnet="${AZURE_CONTAINER_APP_VNET}" \
+              containerAppEnvSubnet="${AZURE_CONTAINER_APP_ENV_SUBNET}" \
+              adminUsername="${VM_USERNAME}" \
+              adminPassword="${VM_PASSWORD}"
 
       - name: Deploy client-agent full infrastructure
         if: ${{ inputs.what_if == false }}
         run: |
-          az deployment group create \
-            --resource-group "${{ env.AZURE_RESOURCE_GROUP }}" \
-            --subscription "${{ env.AZURE_SUBSCRIPTION_ID }}" \
-            --template-file infra/stacks/client-agent/main.bicep \
-            --parameters environmentName="${{ env.AZURE_ENV_NAME }}" \
-              environmentPrefix="${{ env.AZURE_ENV_PREFIX }}" \
-              location="${{ env.AZURE_LOCATION }}" \
-              monitoringActionGroupEmail="${{ env.AZURE_MONITORING_ACTION_GROUP_EMAIL }}" \
-              containerAppManagedEnvironmentNumber="${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}" \
-              containerAppVnet="${{ env.AZURE_CONTAINER_APP_VNET }}" \
-              containerAppEnvSubnet="${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}" \
-              adminUsername="${{ env.VM_USERNAME }}" \
-              adminPassword="${{ env.VM_PASSWORD }}"
+          STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-client-agent"
+          echo "Target stack resource group: ${STACK_RESOURCE_GROUP}"
+
+          az deployment sub create \
+            --name "${STACK_RESOURCE_GROUP}-deploy" \
+            --location "${AZURE_LOCATION}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --template-file infra/stacks/client-agent/subscription.bicep \
+            --parameters environmentName="${AZURE_ENV_NAME}" \
+              environmentPrefix="${AZURE_ENV_PREFIX}" \
+              location="${AZURE_LOCATION}" \
+              monitoringActionGroupEmail="${AZURE_MONITORING_ACTION_GROUP_EMAIL}" \
+              containerAppManagedEnvironmentNumber="${AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER}" \
+              containerAppVnet="${AZURE_CONTAINER_APP_VNET}" \
+              containerAppEnvSubnet="${AZURE_CONTAINER_APP_ENV_SUBNET}" \
+              adminUsername="${VM_USERNAME}" \
+              adminPassword="${VM_PASSWORD}"

--- a/documentation/docs/design/infra-stack-segregation.md
+++ b/documentation/docs/design/infra-stack-segregation.md
@@ -80,6 +80,8 @@ These map to the current known deployment shapes as follows.
 
 Each stack root should deploy an isolated environment by composing the shared Bicep modules it needs directly. Shared resources are therefore a module concern, not a separately deployed stack that other stacks depend on.
 
+Each stack should also own its own Azure resource group. In practice this means a subscription-scope stack entrypoint creates or updates the stack resource group and then deploys the resourceGroup-scoped stack root into it.
+
 ### 4.1 Client agent stack
 
 Represents the current client-agent deployment shape:
@@ -170,6 +172,7 @@ To keep public repository artefacts generic:
 - avoid local-authority names in stack names, resource groups, workflow names, and parameter file names
 - prefer names based on architecture pattern or integration shape
 - keep environment/resource naming inputs generic and reusable
+- keep stack-owned resource group names deterministic and derived from the DfE prefix plus environment and stack suffix
 
 Examples:
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,18 +10,21 @@ Current structure:
 
 Shared Bicep modules live under `infra/modules`.
 
+Each stack root under `infra/stacks` is paired with a subscription-scope wrapper that creates or updates the stack-owned resource group and then deploys the stack into it.
+
 Supported deployment roots:
 
 - `src/app-host/infra` still contains the existing application-layer deployment assets and the current laptop-driven deployment flow for existing client environments
 - `src/SUI.Client/SUI.Client.Watcher/infra/client.bicep` remains a legacy dedicated client-infrastructure root used by the client infra workflow
 - `infra/stacks/client-agent/main.bicep` is the full DfE-hosted test stack root
+- `infra/stacks/*/subscription.bicep` are the stack-owned resource-group entrypoints for the stack roots
 
 CI/CD:
 
 - `.github/workflows/gh-deploy-infra.yml` remains the existing `src/app-host/infra` infrastructure workflow and still drives the current `azd provision` path
 - `.github/workflows/gh-client-infra-deploy.yml` deploys the legacy dedicated client-infrastructure path under `src/SUI.Client/SUI.Client.Watcher/infra`
-- `.github/workflows/gh-client-agent-infra-deploy.yml` deploys the full `client-agent` stack root
-- `.github/workflows/gh-blob-event-processor-infra-deploy.yml` deploys the `blob-event-processor` stack root
+- `.github/workflows/gh-client-agent-infra-deploy.yml` deploys the full `client-agent` stack through its subscription-scope wrapper and stack-owned resource group
+- `.github/workflows/gh-blob-event-processor-infra-deploy.yml` deploys the `blob-event-processor` stack through its subscription-scope wrapper and stack-owned resource group
 - The placeholder/future stacks should gain dedicated workflows when their stack roots become deployable
 
 The intent is that stack roots define environment topology, while application deployment consumes outputs from the selected stack.

--- a/infra/stacks/api-batch-processor/README.md
+++ b/infra/stacks/api-batch-processor/README.md
@@ -2,4 +2,8 @@
 
 This is the placeholder root for the planned batch-oriented architecture.
 
-It exists to reserve the stack boundary and deployment contract without introducing any dependency on `client-agent`. Follow-up work should add the scheduled processing, external API integration, identity, secret, and networking resources required by this architecture directly to this stack.
+It exists to reserve the stack boundary and deployment contract without introducing any dependency on `client-agent`.
+
+`infra/stacks/api-batch-processor/subscription.bicep` is the stack-owned resource-group entrypoint for this stack, although no dedicated deploy workflow exists yet.
+
+Follow-up work should add the scheduled processing, external API integration, identity, secret, and networking resources required by this architecture directly to this stack.

--- a/infra/stacks/api-batch-processor/main.bicep
+++ b/infra/stacks/api-batch-processor/main.bicep
@@ -1,7 +1,7 @@
 targetScope = 'resourceGroup'
 
 @minLength(1)
-@description('The name of the deployment environment')
+@description('Name of the deployment environment used for stack resource naming')
 param environmentName string
 
 @minLength(1)

--- a/infra/stacks/api-batch-processor/subscription.bicep
+++ b/infra/stacks/api-batch-processor/subscription.bicep
@@ -1,0 +1,46 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@description('Name of the deployment environment used for stack resource naming')
+param environmentName string
+
+@minLength(1)
+@description('The prefix used for all deployed resources and the resource-group naming convention')
+param environmentPrefix string
+
+@description('The location used for all deployed resources')
+param location string
+
+var lowercaseEnvironmentName = toLower(environmentName)
+var stackName = 'api-batch-processor'
+var resourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
+var resourceGroupTags = {
+  Product: 'SUI'
+  Environment: environmentName
+  EnvironmentPrefix: environmentPrefix
+  'Service Offering': 'SUI'
+  Stack: stackName
+}
+
+resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: location
+  tags: resourceGroupTags
+}
+
+module stackDeployment 'main.bicep' = {
+  name: '${stackName}-deployment'
+  scope: stackResourceGroup
+  params: {
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    location: location
+  }
+}
+
+output RESOURCE_GROUP_NAME string = stackResourceGroup.name
+output RESOURCE_GROUP_ID string = stackResourceGroup.id
+output STACK_NAME string = stackDeployment.outputs.STACK_NAME
+output STACK_CONTRACT_STATUS string = stackDeployment.outputs.STACK_CONTRACT_STATUS
+output LOCATION string = stackDeployment.outputs.LOCATION
+output TAGS object = stackDeployment.outputs.TAGS

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -11,4 +11,6 @@ Current scope:
 - blob containers for incoming, processed, and success files
 - primary and poison storage queues for the processing job contract
 
+`infra/stacks/blob-event-processor/subscription.bicep` is the stack-owned resource-group entrypoint for this stack. It creates or updates the `blob-event-processor` resource group and then deploys `main.bicep` into it.
+
 Follow-up work should add the Event Grid wiring, ACA Job deployment path, and any further networking/security resources directly to this stack without introducing any dependency on `client-agent`.

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 @minLength(1)
 @maxLength(64)
-@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+@description('Name of the deployment environment used for stack resource naming')
 param environmentName string
 
 @minLength(1)
@@ -40,6 +40,7 @@ var tags = {
   Environment: environmentName
   EnvironmentPrefix: environmentPrefix
   'Service Offering': 'SUI'
+  Stack: 'blob-event-processor'
 }
 
 module identity '../../modules/shared/identity.bicep' = {

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -1,0 +1,93 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@description('Name of the deployment environment used for stack resource naming')
+param environmentName string
+
+@minLength(1)
+@description('The prefix used for all deployed resources and the resource-group naming convention')
+param environmentPrefix string
+
+@minLength(1)
+@description('The version number of the container app managed environment, used for naming convention')
+param containerAppManagedEnvironmentNumber string
+
+@minLength(1)
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@minLength(1)
+@description('Container App environment subnet')
+param containerAppEnvSubnet string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+@minLength(1)
+@description('The email address to be used for monitoring alerts')
+param monitoringActionGroupEmail string
+
+@description('Turn on monitoring alerts')
+param turnOnAlerts bool = false
+
+var lowercaseEnvironmentName = toLower(environmentName)
+var stackName = 'blob-event-processor'
+var resourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
+var resourceGroupTags = {
+  Product: 'SUI'
+  Environment: environmentName
+  EnvironmentPrefix: environmentPrefix
+  'Service Offering': 'SUI'
+  Stack: stackName
+}
+
+resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: location
+  tags: resourceGroupTags
+}
+
+module stackDeployment 'main.bicep' = {
+  name: '${stackName}-deployment'
+  scope: stackResourceGroup
+  params: {
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
+    containerAppVnet: containerAppVnet
+    containerAppEnvSubnet: containerAppEnvSubnet
+    location: location
+    monitoringActionGroupEmail: monitoringActionGroupEmail
+    turnOnAlerts: turnOnAlerts
+  }
+}
+
+output RESOURCE_GROUP_NAME string = stackResourceGroup.name
+output RESOURCE_GROUP_ID string = stackResourceGroup.id
+output STACK_NAME string = stackDeployment.outputs.STACK_NAME
+output LOCATION string = stackDeployment.outputs.LOCATION
+output TAGS object = stackDeployment.outputs.TAGS
+output MANAGED_IDENTITY_CLIENT_ID string = stackDeployment.outputs.MANAGED_IDENTITY_CLIENT_ID
+output MANAGED_IDENTITY_NAME string = stackDeployment.outputs.MANAGED_IDENTITY_NAME
+output MANAGED_IDENTITY_PRINCIPAL_ID string = stackDeployment.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = stackDeployment.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = stackDeployment.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+output AZURE_CONTAINER_REGISTRY_NAME string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_NAME
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_NAME
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+output APPLICATION_INSIGHTS_CONNECTION_STRING string = stackDeployment.outputs.APPLICATION_INSIGHTS_CONNECTION_STRING
+output SECRETS_VAULTURI string = stackDeployment.outputs.SECRETS_VAULTURI
+output SECRETS_VAULT_NAME string = stackDeployment.outputs.SECRETS_VAULT_NAME
+output STORAGE_ACCOUNT_NAME string = stackDeployment.outputs.STORAGE_ACCOUNT_NAME
+output STORAGE_ACCOUNT_ID string = stackDeployment.outputs.STORAGE_ACCOUNT_ID
+output STORAGE_BLOB_ENDPOINT string = stackDeployment.outputs.STORAGE_BLOB_ENDPOINT
+output STORAGE_QUEUE_ENDPOINT string = stackDeployment.outputs.STORAGE_QUEUE_ENDPOINT
+output STORAGE_INCOMING_CONTAINER_NAME string = stackDeployment.outputs.STORAGE_INCOMING_CONTAINER_NAME
+output STORAGE_PROCESSED_CONTAINER_NAME string = stackDeployment.outputs.STORAGE_PROCESSED_CONTAINER_NAME
+output STORAGE_SUCCESS_CONTAINER_NAME string = stackDeployment.outputs.STORAGE_SUCCESS_CONTAINER_NAME
+output STORAGE_QUEUE_NAME string = stackDeployment.outputs.STORAGE_QUEUE_NAME
+output STORAGE_POISON_QUEUE_NAME string = stackDeployment.outputs.STORAGE_POISON_QUEUE_NAME

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -91,3 +91,7 @@ output STORAGE_PROCESSED_CONTAINER_NAME string = stackDeployment.outputs.STORAGE
 output STORAGE_SUCCESS_CONTAINER_NAME string = stackDeployment.outputs.STORAGE_SUCCESS_CONTAINER_NAME
 output STORAGE_QUEUE_NAME string = stackDeployment.outputs.STORAGE_QUEUE_NAME
 output STORAGE_POISON_QUEUE_NAME string = stackDeployment.outputs.STORAGE_POISON_QUEUE_NAME
+output EVENT_GRID_SYSTEM_TOPIC_NAME string = stackDeployment.outputs.EVENT_GRID_SYSTEM_TOPIC_NAME
+output EVENT_GRID_SYSTEM_TOPIC_ID string = stackDeployment.outputs.EVENT_GRID_SYSTEM_TOPIC_ID
+output EVENT_GRID_EVENT_SUBSCRIPTION_NAME string = stackDeployment.outputs.EVENT_GRID_EVENT_SUBSCRIPTION_NAME
+output EVENT_GRID_EVENT_SUBSCRIPTION_ID string = stackDeployment.outputs.EVENT_GRID_EVENT_SUBSCRIPTION_ID

--- a/infra/stacks/client-agent/README.md
+++ b/infra/stacks/client-agent/README.md
@@ -9,4 +9,6 @@ It composes:
 
 The authoritative topology root for this architecture is `infra/stacks/client-agent/main.bicep`.
 
-`.github/workflows/gh-client-agent-infra-deploy.yml` deploys this root. The existing `src/app-host/infra` workflow remains in place via `.github/workflows/gh-deploy-infra.yml`, while the current laptop-driven deployment flow for existing client environments remains documented under `src/app-host/infra/deploy_readme.md`.
+`infra/stacks/client-agent/subscription.bicep` is the stack-owned resource-group entrypoint for this stack. It creates or updates the `client-agent` resource group and then deploys `main.bicep` into it.
+
+`.github/workflows/gh-client-agent-infra-deploy.yml` deploys this wrapper. The existing `src/app-host/infra` workflow remains in place via `.github/workflows/gh-deploy-infra.yml`, while the current laptop-driven deployment flow for existing client environments remains documented under `src/app-host/infra/deploy_readme.md`.

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -2,7 +2,7 @@ targetScope = 'resourceGroup'
 
 @minLength(1)
 @maxLength(64)
-@description('Name of the environment that can be used as part of naming resource convention, the name of the resource group for your application will use this name, prefixed with rg-')
+@description('Name of the deployment environment used for stack resource naming')
 param environmentName string
 
 @minLength(1)
@@ -53,6 +53,7 @@ var tags = {
   Environment: environmentName
   EnvironmentPrefix: environmentPrefix
   'Service Offering': 'SUI'
+  Stack: 'client-agent'
 }
 
 module identity '../../modules/shared/identity.bicep' = {

--- a/infra/stacks/client-agent/subscription.bicep
+++ b/infra/stacks/client-agent/subscription.bicep
@@ -1,0 +1,103 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@description('Name of the deployment environment used for stack resource naming')
+param environmentName string
+
+@minLength(1)
+@description('The prefix used for all deployed resources and the resource-group naming convention')
+param environmentPrefix string
+
+@description('Username for the Virtual Machine.')
+param adminUsername string
+
+@description('Password for the Virtual Machine.')
+@minLength(12)
+@secure()
+param adminPassword string
+
+@minLength(1)
+@description('The version number of the container app managed environment, used for naming convention')
+param containerAppManagedEnvironmentNumber string
+
+@minLength(1)
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@minLength(1)
+@description('Container App environment subnet')
+param containerAppEnvSubnet string
+
+@minLength(1)
+@description('The location used for all deployed resources')
+param location string
+
+@minLength(1)
+@description('The email address to be used for monitoring alerts')
+param monitoringActionGroupEmail string
+
+@description('Turn on monitoring alerts')
+param turnOnAlerts bool = false
+
+@description('Network')
+param clientNetwork string = '192.168.0.128/25'
+
+@description('Subnet Range')
+param clientSubnetRange string = '192.168.0.128/26'
+
+var lowercaseEnvironmentName = toLower(environmentName)
+var stackName = 'client-agent'
+var resourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
+var resourceGroupTags = {
+  Product: 'SUI'
+  Environment: environmentName
+  EnvironmentPrefix: environmentPrefix
+  'Service Offering': 'SUI'
+  Stack: stackName
+}
+
+resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
+  name: resourceGroupName
+  location: location
+  tags: resourceGroupTags
+}
+
+module stackDeployment 'main.bicep' = {
+  name: '${stackName}-deployment'
+  scope: stackResourceGroup
+  params: {
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    adminUsername: adminUsername
+    adminPassword: adminPassword
+    containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
+    containerAppVnet: containerAppVnet
+    containerAppEnvSubnet: containerAppEnvSubnet
+    location: location
+    monitoringActionGroupEmail: monitoringActionGroupEmail
+    turnOnAlerts: turnOnAlerts
+    clientNetwork: clientNetwork
+    clientSubnetRange: clientSubnetRange
+  }
+}
+
+output RESOURCE_GROUP_NAME string = stackResourceGroup.name
+output RESOURCE_GROUP_ID string = stackResourceGroup.id
+output MANAGED_IDENTITY_CLIENT_ID string = stackDeployment.outputs.MANAGED_IDENTITY_CLIENT_ID
+output MANAGED_IDENTITY_NAME string = stackDeployment.outputs.MANAGED_IDENTITY_NAME
+output MANAGED_IDENTITY_PRINCIPAL_ID string = stackDeployment.outputs.MANAGED_IDENTITY_PRINCIPAL_ID
+output AZURE_LOG_ANALYTICS_WORKSPACE_NAME string = stackDeployment.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_NAME
+output AZURE_LOG_ANALYTICS_WORKSPACE_ID string = stackDeployment.outputs.AZURE_LOG_ANALYTICS_WORKSPACE_ID
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID
+output AZURE_CONTAINER_REGISTRY_NAME string = stackDeployment.outputs.AZURE_CONTAINER_REGISTRY_NAME
+output AZURE_CONTAINER_APPS_ENVIRONMENT_NAME string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_NAME
+output AZURE_CONTAINER_APPS_ENVIRONMENT_ID string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_ID
+output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = stackDeployment.outputs.AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN
+output APPLICATION_INSIGHTS_CONNECTION_STRING string = stackDeployment.outputs.APPLICATION_INSIGHTS_CONNECTION_STRING
+output SECRETS_VAULTURI string = stackDeployment.outputs.SECRETS_VAULTURI
+output SECRETS_VAULT_NAME string = stackDeployment.outputs.SECRETS_VAULT_NAME
+output CLIENT_VM_NAME string = stackDeployment.outputs.CLIENT_VM_NAME
+output CLIENT_VIRTUAL_NETWORK_NAME string = stackDeployment.outputs.CLIENT_VIRTUAL_NETWORK_NAME
+output CLIENT_FIREWALL_NAME string = stackDeployment.outputs.CLIENT_FIREWALL_NAME
+output CLIENT_ROUTE_TABLE_NAME string = stackDeployment.outputs.CLIENT_ROUTE_TABLE_NAME


### PR DESCRIPTION
## Summary
This moves the stack deployment model away from shared, pre-created resource groups and toward stack-owned ones.

The aim here is to make each stack responsible for the resource group it lives in, so deployments are cleaner and future teardown/decommission work can be handled at the stack level rather than by manually untangling shared environments.

## Changes

- added subscription scope wrappers for `client-agent`, `blob-event-processor`, and `api-batch-processor` so each stack can create or update its own resource group before deploying the existing stack root
- updated the `client-agent` and `blob-event-processor` workflows to run subscription scoped what-if/deploy against those wrappers instead of targeting a pre-existing shared resource group
- updated the stack and design docs so the expected contract is now that each stack owns its own resource group

## Validation

- ran `az bicep build` for the new subscription wrappers
- checked that the updated workflow YAML parses
