### PR TITLE
ci: SUI-1711 - add stack decommission workflow

### DIFF
--- a/.github/workflows/gh-stack-decommission.yml
+++ b/.github/workflows/gh-stack-decommission.yml
@@ -1,0 +1,123 @@
+name: Decommission Stack Infrastructure
+
+on:
+  workflow_dispatch:
+    inputs:
+      stack:
+        description: The stack to decommission
+        required: true
+        default: client-agent
+        type: choice
+        options:
+          - client-agent
+          - blob-event-processor
+          - api-batch-processor
+      environment:
+        description: The environment target for decommissioning
+        required: true
+        default: 'Integration'
+        type: string
+      environment_prefix:
+        description: The prefix for the environment
+        default: 's215d01'
+        type: string
+      list_only:
+        description: Only inspect the target resource group
+        default: true
+        type: boolean
+      confirm_resource_group:
+        description: Exact resource-group name confirmation required for deletion
+        required: false
+        default: ''
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  decommission:
+    runs-on: ubuntu-latest
+    env:
+      STACK_NAME: ${{ inputs.stack }}
+      AZURE_ENV_NAME: ${{ inputs.environment }}
+      AZURE_ENV_PREFIX: ${{ inputs.environment_prefix }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      CONFIRM_RESOURCE_GROUP: ${{ inputs.confirm_resource_group }}
+
+    steps:
+      - name: Ensure Azure CLI is installed
+        run: |
+          if ! command -v az &> /dev/null; then
+            curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          fi
+
+      - name: Login to Azure
+        uses: azure/login@v3
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Inspect target stack resource group
+        run: |
+          STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-${STACK_NAME}"
+
+          echo "Target stack: ${STACK_NAME}"
+          echo "Target environment: ${AZURE_ENV_NAME}"
+          echo "Target resource group: ${STACK_RESOURCE_GROUP}"
+
+          echo "STACK_RESOURCE_GROUP=${STACK_RESOURCE_GROUP}" >> "${GITHUB_ENV}"
+
+          if az group show \
+            --name "${STACK_RESOURCE_GROUP}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --output none 2>/dev/null; then
+            echo "Resource group exists."
+            echo "RESOURCE_GROUP_EXISTS=true" >> "${GITHUB_ENV}"
+
+            echo "Resources currently in ${STACK_RESOURCE_GROUP}:"
+            az resource list \
+              --resource-group "${STACK_RESOURCE_GROUP}" \
+              --subscription "${AZURE_SUBSCRIPTION_ID}" \
+              --query "[].{name:name,type:type,location:location}" \
+              --output table
+          else
+            echo "Resource group does not exist."
+            echo "RESOURCE_GROUP_EXISTS=false" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Finish after inspection
+        if: ${{ inputs.list_only == true }}
+        run: echo "Inspection completed. No delete requested."
+
+      - name: Validate delete request
+        if: ${{ inputs.list_only == false }}
+        run: |
+          if [ "${RESOURCE_GROUP_EXISTS}" != "true" ]; then
+            echo "Resource group ${STACK_RESOURCE_GROUP} does not exist. Nothing to delete."
+            exit 1
+          fi
+
+          if [ -z "${CONFIRM_RESOURCE_GROUP}" ]; then
+            echo "confirm_resource_group must exactly match ${STACK_RESOURCE_GROUP} to allow deletion."
+            exit 1
+          fi
+
+          if [ "${CONFIRM_RESOURCE_GROUP}" != "${STACK_RESOURCE_GROUP}" ]; then
+            echo "confirm_resource_group (${CONFIRM_RESOURCE_GROUP}) does not match ${STACK_RESOURCE_GROUP}."
+            exit 1
+          fi
+
+      - name: Delete stack resource group
+        if: ${{ inputs.list_only == false }}
+        run: |
+          echo "Deleting resource group ${STACK_RESOURCE_GROUP}"
+          echo "This can take a while depending on the resources in the group."
+          az group delete \
+            --name "${STACK_RESOURCE_GROUP}" \
+            --subscription "${AZURE_SUBSCRIPTION_ID}" \
+            --yes
+          echo "Resource group ${STACK_RESOURCE_GROUP} deleted successfully."

--- a/documentation/docs/design/infra-stack-segregation.md
+++ b/documentation/docs/design/infra-stack-segregation.md
@@ -82,6 +82,8 @@ Each stack root should deploy an isolated environment by composing the shared Bi
 
 Each stack should also own its own Azure resource group. In practice this means a subscription-scope stack entrypoint creates or updates the stack resource group and then deploys the resourceGroup-scoped stack root into it.
 
+Decommissioning should follow the same ownership model. The supported teardown path for these stacks is deleting the entire stack-owned resource group through a manual workflow, rather than trying to selectively remove individual resources from mixed or legacy environments.
+
 ### 4.1 Client agent stack
 
 Represents the current client-agent deployment shape:

--- a/infra/README.md
+++ b/infra/README.md
@@ -25,6 +25,13 @@ CI/CD:
 - `.github/workflows/gh-client-infra-deploy.yml` deploys the legacy dedicated client-infrastructure path under `src/SUI.Client/SUI.Client.Watcher/infra`
 - `.github/workflows/gh-client-agent-infra-deploy.yml` deploys the full `client-agent` stack through its subscription-scope wrapper and stack-owned resource group
 - `.github/workflows/gh-blob-event-processor-infra-deploy.yml` deploys the `blob-event-processor` stack through its subscription-scope wrapper and stack-owned resource group
+- `.github/workflows/gh-stack-decommission.yml` is the generic manual decommission workflow for stack-owned resource groups under `infra/stacks`
 - The placeholder/future stacks should gain dedicated workflows when their stack roots become deployable
 
 The intent is that stack roots define environment topology, while application deployment consumes outputs from the selected stack.
+
+Decommissioning:
+
+- Stack decommissioning for `infra/stacks` means deleting the entire stack-owned resource group.
+- `.github/workflows/gh-stack-decommission.yml` is the supported teardown path for stacks deployed through `infra/stacks/*/subscription.bicep`.
+- The legacy `src/app-host/infra` and `src/SUI.Client/SUI.Client.Watcher/infra` deployment paths are outside that decommission contract.


### PR DESCRIPTION
## Summary

This adds the first proper decommission path for the new `infra/stacks` deployment model.

Rather than trying to tear resources down individually, the workflow treats each stack-owned resource group as the unit of ownership and deletion. That keeps the decommission path aligned with the stack wrapper model introduced in SUI-1712 and avoids trying to support the older mixed deployment paths in the same workflow.

## Changes

- added `.github/workflows/gh-stack-decommission.yml` as a manual decommission workflow for `client-agent`, `blob-event-processor`, and `api-batch-processor`
- made the workflow derive the target resource group name from the same stack/environment naming convention as the stack deployment wrappers
- added safety checks so the workflow inspects the resource group first, defaults to `list_only=true`, and only deletes when `confirm_resource_group` exactly matches the computed RG name
- documented that stack decommissioning for `infra/stacks` means deleting the entire stack-owned resource group
- kept the legacy `src/app-host/infra` and `src/SUI.Client/SUI.Client.Watcher/infra` paths out of scope for this workflow

## Validation

- parsed `.github/workflows/gh-stack-decommission.yml` successfully
- manual testing of workflow to happen once merged 
