### PR TITLE
feat: Create bicep files for external, matching and yarp

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,9 +4,12 @@ title = "SUI GitLeaks configuration"
 useDefault = true
 
 [allowlist]
-description = "Documentation files with known placeholder values"
+description = "Known non-secret values and documentation files with placeholder values"
 paths = [
   '''^documentation/docs/gettingstarted\.md$''',
   '''^documentation/docs/index\.md$''',
   '''^gettingstarted/index.html$''',
+]
+regexes = [
+  '''4633458b-17de-408a-b874-0445c86b69e6''',
 ]

--- a/infra/modules/api-apps/external-api.bicep
+++ b/infra/modules/api-apps/external-api.bicep
@@ -1,0 +1,148 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The resource ID of the Container Apps managed environment')
+param containerAppsEnvironmentId string
+
+@description('The login server for the container registry')
+param containerRegistryServer string
+
+@description('The container registry resource name')
+param containerRegistryName string
+
+@description('The resource ID of the managed identity')
+param managedIdentityId string
+
+@description('The principal ID of the managed identity, used for RBAC assignments')
+param managedIdentityPrincipalId string
+
+@description('The client ID of the managed identity')
+param managedIdentityClientId string
+
+@description('Name of the deployment environment used for ASP.NET runtime configuration')
+param environmentName string
+
+@description('The container image tag to deploy')
+param imageTag string
+
+@secure()
+@description('The Key Vault URI used by the application secrets connection string')
+param keyVaultUri string
+
+@secure()
+@description('The Application Insights connection string')
+param applicationInsightsConnectionString string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var appName = 'external-api'
+var targetPort = 8080
+
+module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
+  name: '${appName}-acr-pull-rbac'
+  params: {
+    containerRegistryName: containerRegistryName
+    principalId: managedIdentityPrincipalId
+  }
+}
+
+resource externalApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
+  name: appName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'single'
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
+      ingress: {
+        external: false
+        targetPort: targetPort
+        transport: 'http'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: containerRegistryServer
+          identity: managedIdentityId
+        }
+      ]
+      secrets: [
+        {
+          name: 'connectionstrings--secrets'
+          value: keyVaultUri
+        }
+        {
+          name: 'app-insights-connection-string'
+          value: applicationInsightsConnectionString
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: appName
+          image: '${containerRegistryServer}/${appName}:${imageTag}'
+          env: [
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: managedIdentityClientId
+            }
+            {
+              name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'HTTP_PORTS'
+              value: string(targetPort)
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'ConnectionStrings__secrets'
+              secretRef: 'connectionstrings--secrets'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: environmentName
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              secretRef: 'app-insights-connection-string'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    acrPullRbac
+  ]
+}
+
+output name string = externalApi.name
+output id string = externalApi.id

--- a/infra/modules/api-apps/external-api.bicep
+++ b/infra/modules/api-apps/external-api.bicep
@@ -25,6 +25,9 @@ param environmentName string
 @description('The container image tag to deploy')
 param imageTag string
 
+@description('The Key Vault resource name used by the application secrets connection string')
+param keyVaultName string
+
 @secure()
 @description('The Key Vault URI used by the application secrets connection string')
 param keyVaultUri string
@@ -43,6 +46,14 @@ module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
   name: '${appName}-acr-pull-rbac'
   params: {
     containerRegistryName: containerRegistryName
+    principalId: managedIdentityPrincipalId
+  }
+}
+
+module keyVaultSecretsUserRbac '../shared/key-vault-secrets-user-rbac.bicep' = {
+  name: '${appName}-kv-secrets-user-rbac'
+  params: {
+    keyVaultName: keyVaultName
     principalId: managedIdentityPrincipalId
   }
 }
@@ -141,6 +152,7 @@ resource externalApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
   }
   dependsOn: [
     acrPullRbac
+    keyVaultSecretsUserRbac
   ]
 }
 

--- a/infra/modules/api-apps/matching-api.bicep
+++ b/infra/modules/api-apps/matching-api.bicep
@@ -1,0 +1,148 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The resource ID of the Container Apps managed environment')
+param containerAppsEnvironmentId string
+
+@description('The default domain of the Container Apps managed environment')
+param containerAppsEnvironmentDefaultDomain string
+
+@description('The login server for the container registry')
+param containerRegistryServer string
+
+@description('The container registry resource name')
+param containerRegistryName string
+
+@description('The resource ID of the managed identity')
+param managedIdentityId string
+
+@description('The principal ID of the managed identity, used for RBAC assignments')
+param managedIdentityPrincipalId string
+
+@description('The client ID of the managed identity')
+param managedIdentityClientId string
+
+@description('Name of the deployment environment used for ASP.NET runtime configuration')
+param environmentName string
+
+@description('The container image tag to deploy')
+param imageTag string
+
+@secure()
+@description('The Application Insights connection string')
+param applicationInsightsConnectionString string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var appName = 'matching-api'
+var externalApiName = 'external-api'
+var targetPort = 8080
+
+module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
+  name: '${appName}-acr-pull-rbac'
+  params: {
+    containerRegistryName: containerRegistryName
+    principalId: managedIdentityPrincipalId
+  }
+}
+
+resource matchingApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
+  name: appName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'single'
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
+      ingress: {
+        external: false
+        targetPort: targetPort
+        transport: 'http'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: containerRegistryServer
+          identity: managedIdentityId
+        }
+      ]
+      secrets: [
+        {
+          name: 'app-insights-connection-string'
+          value: applicationInsightsConnectionString
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: appName
+          image: '${containerRegistryServer}/${appName}:${imageTag}'
+          env: [
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: managedIdentityClientId
+            }
+            {
+              name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'HTTP_PORTS'
+              value: string(targetPort)
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'services__external-api__http__0'
+              value: 'http://${externalApiName}.internal.${containerAppsEnvironmentDefaultDomain}'
+            }
+            {
+              name: 'services__external-api__https__0'
+              value: 'https://${externalApiName}.internal.${containerAppsEnvironmentDefaultDomain}'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: environmentName
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              secretRef: 'app-insights-connection-string'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    acrPullRbac
+  ]
+}
+
+output name string = matchingApi.name
+output id string = matchingApi.id

--- a/infra/modules/api-apps/yarp.bicep
+++ b/infra/modules/api-apps/yarp.bicep
@@ -1,0 +1,148 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The resource ID of the Container Apps managed environment')
+param containerAppsEnvironmentId string
+
+@description('The default domain of the Container Apps managed environment')
+param containerAppsEnvironmentDefaultDomain string
+
+@description('The login server for the container registry')
+param containerRegistryServer string
+
+@description('The container registry resource name')
+param containerRegistryName string
+
+@description('The resource ID of the managed identity')
+param managedIdentityId string
+
+@description('The principal ID of the managed identity, used for RBAC assignments')
+param managedIdentityPrincipalId string
+
+@description('The client ID of the managed identity')
+param managedIdentityClientId string
+
+@description('Name of the deployment environment used for ASP.NET runtime configuration')
+param environmentName string
+
+@description('The container image tag to deploy')
+param imageTag string
+
+@secure()
+@description('The Application Insights connection string')
+param applicationInsightsConnectionString string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var appName = 'yarp'
+var matchingApiName = 'matching-api'
+var targetPort = 8080
+
+module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
+  name: '${appName}-acr-pull-rbac'
+  params: {
+    containerRegistryName: containerRegistryName
+    principalId: managedIdentityPrincipalId
+  }
+}
+
+resource yarp 'Microsoft.App/containerApps@2024-10-02-preview' = {
+  name: appName
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'single'
+      runtime: {
+        dotnet: {
+          autoConfigureDataProtection: true
+        }
+      }
+      ingress: {
+        external: true
+        targetPort: targetPort
+        transport: 'http'
+        allowInsecure: false
+      }
+      registries: [
+        {
+          server: containerRegistryServer
+          identity: managedIdentityId
+        }
+      ]
+      secrets: [
+        {
+          name: 'app-insights-connection-string'
+          value: applicationInsightsConnectionString
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: appName
+          image: '${containerRegistryServer}/${appName}:${imageTag}'
+          env: [
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: managedIdentityClientId
+            }
+            {
+              name: 'ASPNETCORE_FORWARDEDHEADERS_ENABLED'
+              value: 'true'
+            }
+            {
+              name: 'HTTP_PORTS'
+              value: string(targetPort)
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+              value: 'true'
+            }
+            {
+              name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+              value: 'in_memory'
+            }
+            {
+              name: 'services__matching-api__http__0'
+              value: 'http://${matchingApiName}.internal.${containerAppsEnvironmentDefaultDomain}'
+            }
+            {
+              name: 'services__matching-api__https__0'
+              value: 'https://${matchingApiName}.internal.${containerAppsEnvironmentDefaultDomain}'
+            }
+            {
+              name: 'ASPNETCORE_ENVIRONMENT'
+              value: environmentName
+            }
+            {
+              name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+              secretRef: 'app-insights-connection-string'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
+    }
+  }
+  dependsOn: [
+    acrPullRbac
+  ]
+}
+
+output name string = yarp.name
+output id string = yarp.id

--- a/infra/modules/shared/key-vault-secrets-user-rbac.bicep
+++ b/infra/modules/shared/key-vault-secrets-user-rbac.bicep
@@ -1,0 +1,21 @@
+@description('The Key Vault resource name')
+param keyVaultName string
+
+@description('The principal ID to grant the Key Vault Secrets User role')
+param principalId string
+
+var keyVaultSecretsUserRoleId = '4633458b-17de-408a-b874-0445c86b69e6'
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource keyVaultSecretsUserAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  scope: keyVault
+  name: guid(keyVault.id, principalId, keyVaultSecretsUserRoleId)
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultSecretsUserRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}


### PR DESCRIPTION
## Summary

Create new shared bicep files for each of the API's - Matching, External and Yarp.

These match the .tmpl files that azd would automatically build from. Effectivly this avoids the 'Aspire' way of doing it. attempting to use the same .tmpl files would be difficult and potentially require changes to legacy pipeline.

This I believe creates the least friction and is re-usable on any stack. The consequence is we will need dockerfiles for the external, matching and yarp to use the `az acr build` command to build and push the images to the ACR. Docker files to come in next PR if this is approved.

This PR only creates these files, it has not plugged them into the stacks yet

## Changes

- Created external-api.bicep - matching the .tmpl file
- Created matching-api.bicep - matching the .tmpl file
- Created yarp-api.bicep - matching the .tmpl file

## Validation

- az build --file on each file to ensure it validates
- does not effect stacks main.bicep yet
-
