### PR TITLE
feat: 1767 - blob stack private endpoint

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -42,6 +42,10 @@ inputs:
   azure_container_app_env_subnet:
     description: "Container app environment subnet"
     required: true
+  azure_container_app_pe_subnet:
+    description: "Optional container app private endpoint subnet"
+    required: false
+    default: ""
   stack_resource_group:
     description: "Target stack resource group"
     required: true
@@ -108,6 +112,10 @@ runs:
           "containerAppVnet=${{ inputs.azure_container_app_vnet }}"
           "containerAppEnvSubnet=${{ inputs.azure_container_app_env_subnet }}"
         )
+
+        if [ -n "${{ inputs.azure_container_app_pe_subnet }}" ]; then
+          PARAMETERS+=("containerAppPeSubnet=${{ inputs.azure_container_app_pe_subnet }}")
+        fi
 
         if [ -n "${{ inputs.turn_on_alerts }}" ]; then
           PARAMETERS+=("turnOnAlerts=${{ inputs.turn_on_alerts }}")

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -48,6 +48,7 @@ env:
   AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER: ${{ vars.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
   AZURE_CONTAINER_APP_VNET: ${{ secrets.AZURE_CONTAINER_APP_VNET }}
   AZURE_CONTAINER_APP_ENV_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_ENV_SUBNET }}
+  AZURE_CONTAINER_APP_PE_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_PE_SUBNET }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
 
@@ -130,6 +131,7 @@ jobs:
           azure_container_app_managed_environment_number: ${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
+          azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
@@ -166,6 +168,7 @@ jobs:
           azure_container_app_managed_environment_number: ${{ env.AZURE_CONTAINER_APP_MANAGED_ENVIRONMENT_NUMBER }}
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
+          azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -72,6 +72,15 @@ jobs:
       deployment_name: ${{ steps.context.outputs.deployment_name }}
       deployment_mode: ${{ steps.context.outputs.deployment_mode }}
     steps:
+      - name: Validate private endpoint subnet configuration
+        run: |
+          set -euo pipefail
+
+          if [ -z "${AZURE_CONTAINER_APP_PE_SUBNET}" ]; then
+            echo "::error::AZURE_CONTAINER_APP_PE_SUBNET secret must be configured for blob-event-processor infrastructure deployments."
+            exit 1
+          fi
+
       - name: Derive target names
         id: context
         run: |

--- a/infra/modules/blob-event-processor/storage.bicep
+++ b/infra/modules/blob-event-processor/storage.bicep
@@ -10,6 +10,12 @@ param lowercaseEnvironmentName string
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@description('The resource ID of the subnet for private endpoints')
+param peSubnetId string
+
+@description('The resource ID of the virtual network for private DNS zone links')
+param vnetId string
+
 var incomingContainerName = 'incoming'
 var processedContainerName = 'processed'
 var successContainerName = 'success'
@@ -30,8 +36,12 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
     allowBlobPublicAccess: false
     allowSharedKeyAccess: true
     minimumTlsVersion: 'TLS1_2'
-    publicNetworkAccess: 'Enabled'
+    publicNetworkAccess: 'Enabled' // Must be Enabled to allow Trusted Microsoft Services when networkAcls are used
     supportsHttpsTrafficOnly: true
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+    }
   }
 }
 
@@ -68,6 +78,121 @@ resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-
     name: currentQueueName
   }
 ]
+
+// Private Endpoints
+resource blobPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
+  name: '${storageAccountName}-blob-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${storageAccountName}-blob-pe-conn'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'blob'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource queuePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
+  name: '${storageAccountName}-queue-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${storageAccountName}-queue-pe-conn'
+        properties: {
+          privateLinkServiceId: storageAccount.id
+          groupIds: [
+            'queue'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource blobDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.blob.${environment().suffixes.storage}'
+  location: 'global'
+  tags: tags
+}
+
+resource queueDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.queue.${environment().suffixes.storage}'
+  location: 'global'
+  tags: tags
+}
+
+// DNS Zone Links
+resource blobDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: blobDnsZone
+  name: '${storageAccountName}-blob-dns-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource queueDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: queueDnsZone
+  name: '${storageAccountName}-queue-dns-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+// DNS Zone Groups
+resource blobDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
+  parent: blobPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'privatelink-blob-core-windows-net'
+        properties: {
+          privateDnsZoneId: blobDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource queueDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
+  parent: queuePrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: 'privatelink-queue-core-windows-net'
+        properties: {
+          privateDnsZoneId: queueDnsZone.id
+        }
+      }
+    ]
+  }
+}
 
 output accountName string = storageAccount.name
 output accountId string = storageAccount.id

--- a/infra/modules/blob-event-processor/storage.bicep
+++ b/infra/modules/blob-event-processor/storage.bicep
@@ -170,7 +170,7 @@ resource blobDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGrou
   properties: {
     privateDnsZoneConfigs: [
       {
-        name: 'privatelink-blob-core-windows-net'
+        name: replace(blobDnsZone.name, '.', '-')
         properties: {
           privateDnsZoneId: blobDnsZone.id
         }
@@ -185,7 +185,7 @@ resource queueDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGro
   properties: {
     privateDnsZoneConfigs: [
       {
-        name: 'privatelink-queue-core-windows-net'
+        name: replace(queueDnsZone.name, '.', '-')
         properties: {
           privateDnsZoneId: queueDnsZone.id
         }

--- a/infra/modules/shared/container-app-environment.bicep
+++ b/infra/modules/shared/container-app-environment.bicep
@@ -19,6 +19,9 @@ param containerAppVnet string
 @description('Container App environment subnet')
 param containerAppEnvSubnet string
 
+@description('Optional private endpoint subnet address prefix')
+param privateEndpointSubnetAddressPrefix string = ''
+
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
@@ -27,6 +30,16 @@ param logAnalyticsWorkspaceName string
 
 var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
 var dashboardComponentName = '${empty(stackNameSuffix) ? 'aspire' : toLower(stackNameSuffix)}-dashboard-01'
+var containerAppEnvironmentSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-cae-01'
+var privateEndpointSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
+var privateEndpointSubnets = empty(privateEndpointSubnetAddressPrefix) ? [] : [
+  {
+    name: privateEndpointSubnetName
+    properties: {
+      addressPrefix: privateEndpointSubnetAddressPrefix
+    }
+  }
+]
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: logAnalyticsWorkspaceName
@@ -41,9 +54,9 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
         containerAppVnet
       ]
     }
-    subnets: [
+    subnets: concat([
       {
-        name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-cae-01'
+        name: containerAppEnvironmentSubnetName
         properties: {
           addressPrefix: containerAppEnvSubnet
           delegations: [
@@ -56,7 +69,7 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
           ]
         }
       }
-    ]
+    ], privateEndpointSubnets)
   }
 }
 
@@ -87,7 +100,7 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-p
     }
     publicNetworkAccess: 'Disabled'
     vnetConfiguration: {
-      infrastructureSubnetId: '${caeVnet.id}/subnets/${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-cae-01'
+      infrastructureSubnetId: '${caeVnet.id}/subnets/${containerAppEnvironmentSubnetName}'
       internal: true
     }
   }
@@ -104,3 +117,5 @@ output name string = containerAppEnvironment.name
 output id string = containerAppEnvironment.id
 output defaultDomain string = containerAppEnvironment.properties.defaultDomain
 output virtualNetworkName string = caeVnet.name
+output virtualNetworkId string = caeVnet.id
+output privateEndpointSubnetId string = empty(privateEndpointSubnetAddressPrefix) ? '' : '${caeVnet.id}/subnets/${privateEndpointSubnetName}'

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -22,6 +22,10 @@ param containerAppVnet string
 param containerAppEnvSubnet string
 
 @minLength(1)
+@description('The address prefix for the private endpoint subnet')
+param containerAppPeSubnet string
+
+@minLength(1)
 @description('The location used for all deployed resources')
 param location string
 
@@ -38,6 +42,8 @@ param storageProcessJobImageTag string = 'latest'
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
+var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
+var containerAppEnvironmentVnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnet-cae-01'
 
 var tags = {
   'azd-env-name': environmentName
@@ -124,6 +130,21 @@ module monitoring '../../modules/shared/monitoring.bicep' = {
   }
 }
 
+resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' existing = {
+  name: containerAppEnvironmentVnetName
+}
+
+resource peSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-07-01' = {
+  parent: caeVnet
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
+  properties: {
+    addressPrefix: containerAppPeSubnet
+  }
+  dependsOn: [
+    containerAppEnvironment
+  ]
+}
+
 module storage '../../modules/blob-event-processor/storage.bicep' = {
   name: 'blob-event-processor-storage'
   params: {
@@ -131,6 +152,8 @@ module storage '../../modules/blob-event-processor/storage.bicep' = {
     environmentPrefix: environmentPrefix
     lowercaseEnvironmentName: lowercaseEnvironmentName
     tags: tags
+    peSubnetId: peSubnet.id
+    vnetId: caeVnet.id
   }
 }
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -42,8 +42,6 @@ param storageProcessJobImageTag string = 'latest'
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
-var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
-var containerAppEnvironmentVnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnet-cae-01'
 
 var tags = {
   'azd-env-name': environmentName
@@ -105,6 +103,7 @@ module containerAppEnvironment '../../modules/shared/container-app-environment.b
     containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
     containerAppVnet: containerAppVnet
     containerAppEnvSubnet: containerAppEnvSubnet
+    privateEndpointSubnetAddressPrefix: containerAppPeSubnet
     tags: tags
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
   }
@@ -130,21 +129,6 @@ module monitoring '../../modules/shared/monitoring.bicep' = {
   }
 }
 
-resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' existing = {
-  name: containerAppEnvironmentVnetName
-}
-
-resource peSubnet 'Microsoft.Network/virtualNetworks/subnets@2022-07-01' = {
-  parent: caeVnet
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
-  properties: {
-    addressPrefix: containerAppPeSubnet
-  }
-  dependsOn: [
-    containerAppEnvironment
-  ]
-}
-
 module storage '../../modules/blob-event-processor/storage.bicep' = {
   name: 'blob-event-processor-storage'
   params: {
@@ -152,8 +136,8 @@ module storage '../../modules/blob-event-processor/storage.bicep' = {
     environmentPrefix: environmentPrefix
     lowercaseEnvironmentName: lowercaseEnvironmentName
     tags: tags
-    peSubnetId: peSubnet.id
-    vnetId: caeVnet.id
+    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
+    vnetId: containerAppEnvironment.outputs.virtualNetworkId
   }
 }
 

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -21,6 +21,10 @@ param containerAppVnet string
 param containerAppEnvSubnet string
 
 @minLength(1)
+@description('The address prefix for the private endpoint subnet')
+param containerAppPeSubnet string
+
+@minLength(1)
 @description('The location used for all deployed resources')
 param location string
 
@@ -61,6 +65,7 @@ module stackDeployment 'main.bicep' = {
     containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
     containerAppVnet: containerAppVnet
     containerAppEnvSubnet: containerAppEnvSubnet
+    containerAppPeSubnet: containerAppPeSubnet
     location: location
     monitoringActionGroupEmail: monitoringActionGroupEmail
     turnOnAlerts: turnOnAlerts


### PR DESCRIPTION

## Summary

Setup private DNS and private links for between storage and container apps environment.
This also stops public access on the storage containers.

## Changes

- Adds private storage access for blob-event-processor.
- Adds blob and queue private endpoints.
- Adds private DNS zones and VNet links. 
- Locks down storage networking. 
- Adds a private endpoint subnet to the CAE VNet.
- Moves subnet ownership into the CAE module.
- Passes VNet and subnet IDs from CAE outputs.
- Adds containerAppPeSubnet to blob stack inputs.
- Wires the subnet secret into the blob infra workflow.
- Adds early validation for missing PE subnet config.
- Uncommitted: hardens the shared deploy action parameter handling.

## Validation

- what-if action run  https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26288508668
- building locally shows no errors