### PR TITLE
fix: Add 'include role assignments' parameter

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -68,6 +68,11 @@ inputs:
     description: "Optional storage process job image tag"
     required: false
     default: ""
+  include_role_assignments:
+    description: Whether or not to include role assignments, since some environments may restrict these. 
+    default: true
+    type: boolean
+
 
 runs:
   using: "composite"
@@ -111,6 +116,7 @@ runs:
           "containerAppManagedEnvironmentNumber=${{ inputs.azure_container_app_managed_environment_number }}"
           "containerAppVnet=${{ inputs.azure_container_app_vnet }}"
           "containerAppEnvSubnet=${{ inputs.azure_container_app_env_subnet }}"
+          "includeRoleAssignments=${{ inputs.include_role_assignments }}"
         )
 
         if [ -n "${{ inputs.azure_container_app_pe_subnet }}" ]; then

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -31,6 +31,10 @@ on:
         description: Enable monitoring alerts
         default: false
         type: boolean
+      include_role_assignments:
+        description: Whether or not to include role assignments, since some environments may restrict these.
+        default: true
+        type: boolean
 
 permissions:
   id-token: write
@@ -49,6 +53,7 @@ env:
   AZURE_CONTAINER_APP_VNET: ${{ secrets.AZURE_CONTAINER_APP_VNET }}
   AZURE_CONTAINER_APP_ENV_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_ENV_SUBNET }}
   AZURE_CONTAINER_APP_PE_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_PE_SUBNET }}
+  AZURE_INCLUDE_ROLE_ASSIGNMENTS: ${{ inputs.include_role_assignments }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
 
@@ -141,6 +146,7 @@ jobs:
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
+          azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
@@ -178,6 +184,7 @@ jobs:
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
+          azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -40,6 +40,9 @@ param turnOnAlerts bool = false
 @description('Container image tag for the storage process job')
 param storageProcessJobImageTag string = 'latest'
 
+@description('Whether or not to include role assignments, since some environments may restrict these.')
+param includeRoleAssignments bool = true
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
 
@@ -74,7 +77,7 @@ module containerRegistry '../../modules/shared/container-registry.bicep' = {
   }
 }
 
-module storageProcessJobAcrPullRbac '../../modules/shared/acr-pull-rbac.bicep' = {
+module storageProcessJobAcrPullRbac '../../modules/shared/acr-pull-rbac.bicep' = if (includeRoleAssignments) {
   name: 'storage-process-job-acr-pull-rbac'
   params: {
     containerRegistryName: containerRegistry.outputs.name


### PR DESCRIPTION
Required to account for cloud environments where access to assign roles is restricted. Roles can be added manually or through due process.

Tried to find something that could 'import' the assignments back into the bicep deployments, but no such thing exists.
