### PR TITLE
feat: SUI-1973 - update blob stack to support existing resources

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -72,6 +72,22 @@ inputs:
     description: Whether or not to include role assignments, since some environments may restrict these. 
     default: true
     type: boolean
+  resource_group_mode:
+    description: "Optional resource group mode: create or existing"
+    required: false
+    default: ""
+  target_resource_group_name:
+    description: "Optional existing resource group name when resource_group_mode is existing"
+    required: false
+    default: ""
+  storage_account_mode:
+    description: "Optional storage account mode: create or existing"
+    required: false
+    default: ""
+  existing_storage_account_name:
+    description: "Optional existing storage account name when storage_account_mode is existing"
+    required: false
+    default: ""
 
 
 runs:
@@ -137,6 +153,22 @@ runs:
 
         if [ -n "${{ inputs.storage_process_job_image_tag }}" ]; then
           PARAMETERS+=("storageProcessJobImageTag=${{ inputs.storage_process_job_image_tag }}")
+        fi
+
+        if [ -n "${{ inputs.resource_group_mode }}" ]; then
+          PARAMETERS+=("resourceGroupMode=${{ inputs.resource_group_mode }}")
+        fi
+
+        if [ -n "${{ inputs.target_resource_group_name }}" ]; then
+          PARAMETERS+=("targetResourceGroupName=${{ inputs.target_resource_group_name }}")
+        fi
+
+        if [ -n "${{ inputs.storage_account_mode }}" ]; then
+          PARAMETERS+=("storageAccountMode=${{ inputs.storage_account_mode }}")
+        fi
+
+        if [ -n "${{ inputs.existing_storage_account_name }}" ]; then
+          PARAMETERS+=("existingStorageAccountName=${{ inputs.existing_storage_account_name }}")
         fi
 
         cleanup() {

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -35,6 +35,28 @@ on:
         description: Include role assignments? # since some environments may restrict these.
         default: true
         type: boolean
+      resource_group_mode:
+        description: Resource group mode
+        default: create
+        type: choice
+        options:
+          - create
+          - existing
+      target_resource_group_name:
+        description: Existing resource group name when resource_group_mode is existing
+        required: false
+        type: string
+      storage_account_mode:
+        description: Storage account mode
+        default: create
+        type: choice
+        options:
+          - create
+          - existing
+      existing_storage_account_name:
+        description: Existing storage account name when storage_account_mode is existing
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -56,6 +78,10 @@ env:
   AZURE_INCLUDE_ROLE_ASSIGNMENTS: ${{ inputs.include_role_assignments }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
+  RESOURCE_GROUP_MODE: ${{ inputs.resource_group_mode || 'create' }}
+  TARGET_RESOURCE_GROUP_NAME: ${{ inputs.target_resource_group_name }}
+  STORAGE_ACCOUNT_MODE: ${{ inputs.storage_account_mode || 'create' }}
+  EXISTING_STORAGE_ACCOUNT_NAME: ${{ inputs.existing_storage_account_name }}
 
 concurrency:
   group: blob-event-processor-${{ inputs.environment_prefix }}-${{ inputs.environment }}
@@ -91,6 +117,19 @@ jobs:
         run: |
           set -euo pipefail
           STACK_RESOURCE_GROUP="${AZURE_ENV_PREFIX}-${AZURE_ENV_NAME,,}-${STACK_NAME}"
+          if [ "${RESOURCE_GROUP_MODE}" = "existing" ]; then
+            if [ -z "${TARGET_RESOURCE_GROUP_NAME}" ]; then
+              echo "::error::target_resource_group_name must be set when resource_group_mode is existing."
+              exit 1
+            fi
+            STACK_RESOURCE_GROUP="${TARGET_RESOURCE_GROUP_NAME}"
+          fi
+
+          if [ "${STORAGE_ACCOUNT_MODE}" = "existing" ] && [ -z "${EXISTING_STORAGE_ACCOUNT_NAME}" ]; then
+            echo "::error::existing_storage_account_name must be set when storage_account_mode is existing."
+            exit 1
+          fi
+
           DEPLOYMENT_NAME="${STACK_RESOURCE_GROUP}-${AZURE_LOCATION,,}-${DEPLOYMENT_MODE}"
 
           {
@@ -111,6 +150,8 @@ jobs:
             echo "- Azure location: \`${AZURE_LOCATION}\`"
             echo "- Version/ref: \`${STACK_VERSION}\`"
             echo "- Resource group: \`${STACK_RESOURCE_GROUP}\`"
+            echo "- Resource group mode: \`${RESOURCE_GROUP_MODE}\`"
+            echo "- Storage account mode: \`${STORAGE_ACCOUNT_MODE}\`"
             echo "- Deployment name: \`${DEPLOYMENT_NAME}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -151,6 +192,10 @@ jobs:
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
           storage_process_job_image_tag: ${{ env.STORAGE_PROCESS_JOB_IMAGE_TAG }}
+          resource_group_mode: ${{ env.RESOURCE_GROUP_MODE }}
+          target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
+          storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}
+          existing_storage_account_name: ${{ env.EXISTING_STORAGE_ACCOUNT_NAME }}
 
   deploy:
     name: Deploy blob-event-processor infrastructure
@@ -189,6 +234,10 @@ jobs:
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
           storage_process_job_image_tag: ${{ env.STORAGE_PROCESS_JOB_IMAGE_TAG }}
+          resource_group_mode: ${{ env.RESOURCE_GROUP_MODE }}
+          target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
+          storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}
+          existing_storage_account_name: ${{ env.EXISTING_STORAGE_ACCOUNT_NAME }}
 
   summarize:
     name: Summarize blob-event-processor run

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,6 +12,8 @@ Shared Bicep modules live under `infra/modules`.
 
 Each stack root under `infra/stacks` is paired with a subscription-scope wrapper that creates or updates the stack-owned resource group and then deploys the stack into it.
 
+The `blob-event-processor` wrapper also supports deploying into an existing resource group and using an existing storage account. In that mode, the stack still creates its standard blob containers and storage queues, but it does not create the storage account or private endpoints for that existing account.
+
 Supported deployment roots:
 
 - `src/app-host/infra` is a legacy application-layer deployment path for existing client environments. It is intentionally frozen: new infrastructure capability — including registry/RBAC modules such as `acr-pull-rbac` — is added to the stack roots under `infra/stacks`, not retrofitted onto `app-host`. The new stacks own the full container-registry → managed-identity → AcrPull chain in code; the legacy path does not, and is deliberately not partially converted.
@@ -34,4 +36,5 @@ Decommissioning:
 
 - Stack decommissioning for `infra/stacks` means deleting the entire stack-owned resource group.
 - `.github/workflows/gh-stack-decommission.yml` is the supported teardown path for stacks deployed through `infra/stacks/*/subscription.bicep`.
+- Deployments made with `resourceGroupMode=existing` are outside the stack-owned resource group teardown contract and must be cleaned up selectively.
 - The legacy `src/app-host/infra` and `src/SUI.Client/SUI.Client.Watcher/infra` deployment paths are outside that decommission contract.

--- a/infra/modules/blob-event-processor/existing-storage.bicep
+++ b/infra/modules/blob-event-processor/existing-storage.bicep
@@ -1,12 +1,6 @@
 @description('The location used for all deployed resources')
 param location string
 
-@description('The prefix used for all deployed resources')
-param environmentPrefix string
-
-@description('The lowercase environment name used for resource naming')
-param lowercaseEnvironmentName string
-
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
@@ -16,28 +10,12 @@ param peSubnetId string
 @description('The resource ID of the virtual network for private DNS zone links')
 param vnetId string
 
-var storageAccountName = toLower('${take(environmentPrefix, 8)}${take(lowercaseEnvironmentName, 8)}bep${take(uniqueString(resourceGroup().id, environmentPrefix, lowercaseEnvironmentName), 5)}')
+@minLength(3)
+@description('The name of the existing storage account to use.')
+param storageAccountName string
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
-  location: location
-  kind: 'StorageV2'
-  sku: {
-    name: 'Standard_LRS'
-  }
-  tags: tags
-  properties: {
-    accessTier: 'Hot'
-    allowBlobPublicAccess: false
-    allowSharedKeyAccess: true
-    minimumTlsVersion: 'TLS1_2'
-    publicNetworkAccess: 'Enabled' // Must be Enabled to allow Trusted Microsoft Services when networkAcls are used
-    supportsHttpsTrafficOnly: true
-    networkAcls: {
-      bypass: 'AzureServices'
-      defaultAction: 'Deny'
-    }
-  }
 }
 
 module storageResources './storage-resources.bicep' = {

--- a/infra/modules/blob-event-processor/storage-resources.bicep
+++ b/infra/modules/blob-event-processor/storage-resources.bicep
@@ -1,0 +1,175 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('The name of the storage account to configure')
+param storageAccountName string
+
+@description('The resource ID of the storage account to configure')
+param storageAccountId string
+
+@description('The resource ID of the subnet for private endpoints')
+param peSubnetId string
+
+@description('The resource ID of the virtual network for private DNS zone links')
+param vnetId string
+
+var incomingContainerName = 'incoming'
+var processedContainerName = 'processed'
+var successContainerName = 'success'
+var queueName = 'storage-process-job'
+var poisonQueueName = '${queueName}-poison'
+var containerNames = [
+  incomingContainerName
+  processedContainerName
+  successContainerName
+]
+var queueNames = [
+  queueName
+  poisonQueueName
+]
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  name: '${storageAccountName}/default'
+}
+
+resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = [
+  for containerName in containerNames: {
+    parent: blobService
+    name: containerName
+    properties: {
+      publicAccess: 'None'
+    }
+  }
+]
+
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' = {
+  name: '${storageAccountName}/default'
+}
+
+resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = [
+  for currentQueueName in queueNames: {
+    parent: queueService
+    name: currentQueueName
+  }
+]
+
+resource blobPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
+  name: '${storageAccountName}-blob-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${storageAccountName}-blob-pe-conn'
+        properties: {
+          privateLinkServiceId: storageAccountId
+          groupIds: [
+            'blob'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource queuePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
+  name: '${storageAccountName}-queue-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${storageAccountName}-queue-pe-conn'
+        properties: {
+          privateLinkServiceId: storageAccountId
+          groupIds: [
+            'queue'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+resource blobDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.blob.${environment().suffixes.storage}'
+  location: 'global'
+  tags: tags
+}
+
+resource queueDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.queue.${environment().suffixes.storage}'
+  location: 'global'
+  tags: tags
+}
+
+resource blobDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: blobDnsZone
+  name: '${storageAccountName}-blob-dns-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource queueDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: queueDnsZone
+  name: '${storageAccountName}-queue-dns-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource blobDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
+  parent: blobPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(blobDnsZone.name, '.', '-')
+        properties: {
+          privateDnsZoneId: blobDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+resource queueDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
+  parent: queuePrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(queueDnsZone.name, '.', '-')
+        properties: {
+          privateDnsZoneId: queueDnsZone.id
+        }
+      }
+    ]
+  }
+}
+
+output incomingContainerName string = incomingContainerName
+output processedContainerName string = processedContainerName
+output successContainerName string = successContainerName
+output queueName string = queueName
+output poisonQueueName string = poisonQueueName

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -2,16 +2,89 @@
 
 This stack is the deployable foundation for the event-driven processing architecture.
 
-It composes the shared platform modules directly and adds the initial blob/queue storage resources needed by the storage-driven processing path.
+It composes the shared platform modules directly and adds the blob/queue storage resources needed by the storage-driven processing path.
 
 Current scope:
 
 - shared platform resources for this stack
-- storage account
+- storage account, either created by the stack or supplied as an existing account
 - blob containers for incoming, processed, and success files
 - primary and poison storage queues for the processing job contract
+- blob and queue private endpoints for the configured storage account
 
-`infra/stacks/blob-event-processor/subscription.bicep` is the stack-owned resource-group entry point for this stack. It creates or updates the `blob-event-processor` resource group and then deploys `main.bicep` into it.
+`infra/stacks/blob-event-processor/subscription.bicep` is the subscription-scope entry point for this stack. By default, `resourceGroupMode=create` creates or updates the stack-owned `blob-event-processor` resource group and then deploys `main.bicep` into it.
+
+It can also deploy into an existing resource group by setting:
+
+- `resourceGroupMode=existing`
+- `targetResourceGroupName=<existing-resource-group-name>`
+
+## Storage modes
+
+The default storage mode is `storageAccountMode=create`. In this mode the stack creates the storage account, the blob/queue containers, and the blob/queue private endpoints and private DNS wiring.
+
+For client-provided storage, set:
+
+- `storageAccountMode=existing`
+- `existingStorageAccountName=<existing-storage-account-name>`
+
+Existing storage mode expects the storage account to already exist in the target resource group. The stack creates the SUI-owned containers and queues in that account:
+
+- `incoming`
+- `processed`
+- `success`
+- `storage-process-job`
+- `storage-process-job-poison`
+
+Both storage modes create blob and queue private endpoints plus private DNS wiring for the configured storage account. In existing storage mode, the private endpoints target the supplied account.
+
+## GitHub workflow behaviour
+
+The deploy workflow wraps the same subscription-scope Bicep template and adds a small amount of shell logic:
+
+- logs in to Azure using GitHub OIDC
+- validates `containerAppPeSubnet` is configured
+- validates `targetResourceGroupName` when `resourceGroupMode=existing`
+- validates `existingStorageAccountName` when `storageAccountMode=existing`
+- derives the stack resource group as `${environmentPrefix}-${environmentName,,}-blob-event-processor`, unless an existing resource group is supplied
+- derives the deployment name as `${resourceGroupName}-${location,,}-${mode}`
+- runs `az deployment sub what-if` or `az deployment sub create`
+- writes GitHub summaries, template outputs, and a post-deploy resource inventory
+
+## Direct deployment
+
+Some client environments may need to be deployed from an approved device rather than GitHub Actions. The same subscription-scope entry point can be used directly:
+
+```bash
+az login
+az account set --subscription <subscription-id>
+
+az deployment sub what-if \
+  --name <deployment-name> \
+  --location <location> \
+  --subscription <subscription-id> \
+  --template-file infra/stacks/blob-event-processor/subscription.bicep \
+  --parameters \
+    environmentName=<environment-name> \
+    environmentPrefix=<environment-prefix> \
+    location=<location> \
+    monitoringActionGroupEmail=<email> \
+    containerAppManagedEnvironmentNumber=<number> \
+    containerAppVnet=<vnet-cidr> \
+    containerAppEnvSubnet=<aca-subnet-cidr> \
+    containerAppPeSubnet=<private-endpoint-subnet-cidr> \
+    includeRoleAssignments=true \
+    storageProcessJobImageTag=<image-tag> \
+    turnOnAlerts=false \
+    resourceGroupMode=existing \
+    targetResourceGroupName=<existing-resource-group-name> \
+    storageAccountMode=existing \
+    existingStorageAccountName=<existing-storage-account-name>
+```
+
+Use `az deployment sub create` with the same parameters to deploy after reviewing the what-if output.
+
+If Azure CLI cannot write to the default local config directory, set `AZURE_CONFIG_DIR` to a writable temporary directory before running the commands.
 
 Follow up work:
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -43,6 +43,16 @@ param storageProcessJobImageTag string = 'latest'
 @description('Whether or not to include role assignments, since some environments may restrict these.')
 param includeRoleAssignments bool = true
 
+@allowed([
+  'create'
+  'existing'
+])
+@description('Whether the stack should create its storage account or use an existing account in the target resource group.')
+param storageAccountMode string = 'create'
+
+@description('The name of the existing storage account to use when storageAccountMode is existing.')
+param existingStorageAccountName string = ''
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
 
@@ -132,7 +142,7 @@ module monitoring '../../modules/shared/monitoring.bicep' = {
   }
 }
 
-module storage '../../modules/blob-event-processor/storage.bicep' = {
+module createdStorage '../../modules/blob-event-processor/storage.bicep' = if (storageAccountMode == 'create') {
   name: 'blob-event-processor-storage'
   params: {
     location: location
@@ -144,15 +154,36 @@ module storage '../../modules/blob-event-processor/storage.bicep' = {
   }
 }
 
+module existingStorage '../../modules/blob-event-processor/existing-storage.bicep' = if (storageAccountMode == 'existing') {
+  name: 'blob-event-processor-existing-storage'
+  params: {
+    location: location
+    tags: tags
+    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
+    vnetId: containerAppEnvironment.outputs.virtualNetworkId
+    storageAccountName: existingStorageAccountName
+  }
+}
+
+var storageAccountName = storageAccountMode == 'create' ? createdStorage!.outputs.accountName : existingStorage!.outputs.accountName
+var storageAccountId = storageAccountMode == 'create' ? createdStorage!.outputs.accountId : existingStorage!.outputs.accountId
+var storageBlobEndpoint = storageAccountMode == 'create' ? createdStorage!.outputs.blobEndpoint : existingStorage!.outputs.blobEndpoint
+var storageQueueEndpoint = storageAccountMode == 'create' ? createdStorage!.outputs.queueEndpoint : existingStorage!.outputs.queueEndpoint
+var storageIncomingContainerName = storageAccountMode == 'create' ? createdStorage!.outputs.incomingContainerName : existingStorage!.outputs.incomingContainerName
+var storageProcessedContainerName = storageAccountMode == 'create' ? createdStorage!.outputs.processedContainerName : existingStorage!.outputs.processedContainerName
+var storageSuccessContainerName = storageAccountMode == 'create' ? createdStorage!.outputs.successContainerName : existingStorage!.outputs.successContainerName
+var storageQueueName = storageAccountMode == 'create' ? createdStorage!.outputs.queueName : existingStorage!.outputs.queueName
+var storagePoisonQueueName = storageAccountMode == 'create' ? createdStorage!.outputs.poisonQueueName : existingStorage!.outputs.poisonQueueName
+
 module eventGrid '../../modules/blob-event-processor/event-grid.bicep' = {
   name: 'blob-event-processor-event-grid'
   params: {
     location: location
     environmentPrefix: environmentPrefix
     lowercaseEnvironmentName: lowercaseEnvironmentName
-    storageAccountId: storage.outputs.accountId
-    queueName: storage.outputs.queueName
-    incomingContainerName: storage.outputs.incomingContainerName
+    storageAccountId: storageAccountId
+    queueName: storageQueueName
+    incomingContainerName: storageIncomingContainerName
     tags: tags
   }
 }
@@ -167,10 +198,10 @@ module storageProcessJob '../../modules/blob-event-processor/container-app-job.b
     managedIdentityId: identity.outputs.id
     managedIdentityPrincipalId: identity.outputs.principalId
     managedIdentityClientId: identity.outputs.clientId
-    storageAccountName: storage.outputs.accountName
-    queueName: storage.outputs.queueName
-    blobServiceUri: storage.outputs.blobEndpoint
-    queueServiceUri: storage.outputs.queueEndpoint
+    storageAccountName: storageAccountName
+    queueName: storageQueueName
+    blobServiceUri: storageBlobEndpoint
+    queueServiceUri: storageQueueEndpoint
     containerRegistryServer: containerRegistry.outputs.endpoint
     imageTag: storageProcessJobImageTag
     matchApiBaseAddress: 'https://matching-api.internal.${containerAppEnvironment.outputs.defaultDomain}'
@@ -199,15 +230,15 @@ output AZURE_CONTAINER_APPS_ENVIRONMENT_DEFAULT_DOMAIN string = containerAppEnvi
 output APPLICATION_INSIGHTS_CONNECTION_STRING string = observability.outputs.applicationInsightsConnectionString
 output SECRETS_VAULTURI string = secrets.outputs.vaultUri
 output SECRETS_VAULT_NAME string = secrets.outputs.name
-output STORAGE_ACCOUNT_NAME string = storage.outputs.accountName
-output STORAGE_ACCOUNT_ID string = storage.outputs.accountId
-output STORAGE_BLOB_ENDPOINT string = storage.outputs.blobEndpoint
-output STORAGE_QUEUE_ENDPOINT string = storage.outputs.queueEndpoint
-output STORAGE_INCOMING_CONTAINER_NAME string = storage.outputs.incomingContainerName
-output STORAGE_PROCESSED_CONTAINER_NAME string = storage.outputs.processedContainerName
-output STORAGE_SUCCESS_CONTAINER_NAME string = storage.outputs.successContainerName
-output STORAGE_QUEUE_NAME string = storage.outputs.queueName
-output STORAGE_POISON_QUEUE_NAME string = storage.outputs.poisonQueueName
+output STORAGE_ACCOUNT_NAME string = storageAccountName
+output STORAGE_ACCOUNT_ID string = storageAccountId
+output STORAGE_BLOB_ENDPOINT string = storageBlobEndpoint
+output STORAGE_QUEUE_ENDPOINT string = storageQueueEndpoint
+output STORAGE_INCOMING_CONTAINER_NAME string = storageIncomingContainerName
+output STORAGE_PROCESSED_CONTAINER_NAME string = storageProcessedContainerName
+output STORAGE_SUCCESS_CONTAINER_NAME string = storageSuccessContainerName
+output STORAGE_QUEUE_NAME string = storageQueueName
+output STORAGE_POISON_QUEUE_NAME string = storagePoisonQueueName
 output EVENT_GRID_SYSTEM_TOPIC_NAME string = eventGrid.outputs.systemTopicName
 output EVENT_GRID_SYSTEM_TOPIC_ID string = eventGrid.outputs.systemTopicId
 output EVENT_GRID_EVENT_SUBSCRIPTION_NAME string = eventGrid.outputs.eventSubscriptionName

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -42,9 +42,30 @@ param storageProcessJobImageTag string = 'latest'
 @description('Whether or not to include role assignments, since some environments may restrict these.')
 param includeRoleAssignments bool = true
 
+@allowed([
+  'create'
+  'existing'
+])
+@description('Whether the subscription wrapper should create the stack resource group or deploy into an existing one.')
+param resourceGroupMode string = 'create'
+
+@description('The existing resource group name to deploy into when resourceGroupMode is existing.')
+param targetResourceGroupName string = ''
+
+@allowed([
+  'create'
+  'existing'
+])
+@description('Whether the stack should create its storage account or use an existing account in the target resource group.')
+param storageAccountMode string = 'create'
+
+@description('The name of the existing storage account to use when storageAccountMode is existing.')
+param existingStorageAccountName string = ''
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'blob-event-processor'
-var resourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
+var stackResourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
+var deploymentResourceGroupName = resourceGroupMode == 'existing' ? targetResourceGroupName : stackResourceGroupName
 var resourceGroupTags = {
   Product: 'SUI'
   Environment: environmentName
@@ -53,15 +74,15 @@ var resourceGroupTags = {
   Stack: stackName
 }
 
-resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = {
-  name: resourceGroupName
+resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = if (resourceGroupMode == 'create') {
+  name: stackResourceGroupName
   location: location
   tags: resourceGroupTags
 }
 
 module stackDeployment 'main.bicep' = {
   name: '${stackName}-deployment'
-  scope: stackResourceGroup
+  scope: resourceGroup(deploymentResourceGroupName)
   params: {
     environmentName: environmentName
     environmentPrefix: environmentPrefix
@@ -74,11 +95,16 @@ module stackDeployment 'main.bicep' = {
     turnOnAlerts: turnOnAlerts
     storageProcessJobImageTag: storageProcessJobImageTag
     includeRoleAssignments: includeRoleAssignments
+    storageAccountMode: storageAccountMode
+    existingStorageAccountName: existingStorageAccountName
   }
+  dependsOn: [
+    stackResourceGroup
+  ]
 }
 
-output RESOURCE_GROUP_NAME string = stackResourceGroup.name
-output RESOURCE_GROUP_ID string = stackResourceGroup.id
+output RESOURCE_GROUP_NAME string = deploymentResourceGroupName
+output RESOURCE_GROUP_ID string = subscriptionResourceId('Microsoft.Resources/resourceGroups', deploymentResourceGroupName)
 output STACK_NAME string = stackDeployment.outputs.STACK_NAME
 output LOCATION string = stackDeployment.outputs.LOCATION
 output TAGS object = stackDeployment.outputs.TAGS


### PR DESCRIPTION
## Summary

Updates the blob-event-processor stack so it can deploy either fully stack-owned resources or integrate with client-provided resources. This keeps the current default create path, while adding an existing resource group / existing storage account mode for client environments.

## Changes

- Adds resource group and storage account modes using `create` / `existing` values.
- Updates the storage module to create our standard containers, queues, blob/queue private endpoints, and private DNS wiring against either a created or existing storage account.
- Wires the new parameters through the blob stack subscription wrapper, stack root, GitHub workflow, and shared stack deploy action.
- Documents direct `az deployment sub` usage for environments deployed from an approved device rather than GitHub Actions.

## Validation

- `az bicep build` of each file
- yaml parser checks

## Notes

- Existing storage mode still uses our standard names: `incoming`, `processed`, `success`, `storage-process-job`, and `storage-process-job-poison`.
- Existing resource group deployments are outside the stack-owned resource group teardown contract and need selective cleanup.
- Need to validate these changes work by spinning up "existing resources" in an Azure RG to simulate the client infra
