### PR TITLE
fix: base64 the queue message

### DIFF
--- a/scripts/test-storage-process-function.ps1
+++ b/scripts/test-storage-process-function.ps1
@@ -122,13 +122,16 @@ $message = @(
         metadataVersion = "1"
     }
 ) | ConvertTo-Json -Compress -Depth 5
+$encodedMessage = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($message))
 
 az storage message put `
     --queue-name $QueueName `
-    --content $message `
+    --content $encodedMessage `
     --connection-string $ConnectionString `
     --only-show-errors | Out-Null
 
 Write-Host "Uploaded blob to $ContainerName/$BlobName"
-Write-Host "Added queue message:"
+Write-Host "Added base64 queue message:"
+Write-Host $encodedMessage
+Write-Host "Decoded queue message:"
 Write-Host $message

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -1,4 +1,4 @@
-﻿// See https://aka.ms/new-console-template for more information
+// See https://aka.ms/new-console-template for more information
 
 using Azure.Identity;
 using Azure.Storage.Blobs;
@@ -67,9 +67,11 @@ builder.Services.AddSingleton(serviceProvider =>
 {
     var configuration = serviceProvider.GetRequiredService<IConfiguration>();
     var connectionString = configuration["AzureWebJobsStorage"];
+    var options = new QueueClientOptions { MessageEncoding = QueueMessageEncoding.Base64 };
+
     if (!string.IsNullOrWhiteSpace(connectionString))
     {
-        return new QueueServiceClient(connectionString);
+        return new QueueServiceClient(connectionString, options);
     }
 
     var uri =
@@ -77,7 +79,7 @@ builder.Services.AddSingleton(serviceProvider =>
         ?? throw new InvalidOperationException(
             "StorageProcessJob:QueueServiceUri must be configured when AzureWebJobsStorage is not set."
         );
-    return new QueueServiceClient(new Uri(uri), new DefaultAzureCredential());
+    return new QueueServiceClient(new Uri(uri), new DefaultAzureCredential(), options);
 });
 
 builder.Services.AddSingleton<IBlobStorageClient, AzureBlobStorageClient>();


### PR DESCRIPTION


## Summary

When running in the application in azure, there is an error that it could not process the event grid message. Further investigation showed that it defaults to Base64 messaging. This update ensures our code is Base64 as well

## Changes

- Updated processor job Program.cs to use Base64 on Queue setup
- Updated the local run script to Base64

## Validation

- Run unit tests
- Run locally using test script and successfully processed the file
