### PR TITLE
feat: apply latest tag on blob event processor deploys

### DIFF
--- a/.github/workflows/gh-blob-event-processor-storage-job-image.yml
+++ b/.github/workflows/gh-blob-event-processor-storage-job-image.yml
@@ -116,6 +116,7 @@ jobs:
           az acr build \
             --registry "${{ steps.context.outputs.acr_name }}" \
             --image "${IMAGE_REPOSITORY}:${{ steps.context.outputs.image_tag }}" \
+            --image "${IMAGE_REPOSITORY}:latest" \
             --file src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile \
             --build-arg MATCH_API_BASE_ADDRESS="${{ steps.context.outputs.match_api_base_address }}" \
             --build-arg CSV_DATE_FORMAT=yyyy-MM-dd \


### PR DESCRIPTION

## Summary

At the moment we only use commit hashes. In order to speed up development and ensure were on latest changes, we add the 'latest' tag to deploys

## Changes

- Added the 'latest' tag in the image deploy

## Validation

- None until we deploy and test it. But it should have no negative impact as azure manages the 'latest' tag automatically for older containers.
