### PR TITLE
feat: 1762 - firewall and peering

### DIFF
--- a/infra/modules/client-agent/infrastructure.bicep
+++ b/infra/modules/client-agent/infrastructure.bicep
@@ -21,32 +21,11 @@ param subnetRange string = '192.168.0.128/26'
 @description('The location used for all deployed resources')
 param location string = resourceGroup().location
 
-@description('The name of the container app environment virtual network')
-param containerAppEnvironmentVnetName string
-
-@description('The resource group that contains the container app environment virtual network')
-param containerAppEnvironmentResourceGroupName string = resourceGroup().name
-
 @description('The name of the shared Log Analytics workspace')
 param logAnalyticsWorkspaceName string
 
 @description('The resource group that contains the shared Log Analytics workspace')
 param logAnalyticsWorkspaceResourceGroupName string = resourceGroup().name
-
-@description('The login server for the shared container registry')
-param containerRegistryEndpoint string
-
-@description('The name of the shared Key Vault')
-param keyVaultName string = '${environmentPrefix}-${substring(toLower(environmentName), 0, environmentName == 'Production' ? 4 : 3)}-ca-kv01'
-
-@description('The Key Vault FQDN allowed through the client-agent firewall')
-param keyVaultEndpoint string = '${keyVaultName}.vault.azure.net'
-
-param virtualNetworksVnetfwName string = '${environmentPrefix}-${toLower(environmentName)}-ca-vnetfw-01'
-
-param vnetFirewallName string = '${environmentPrefix}-${toLower(environmentName)}-ca-vnetfw-Firewall'
-
-param routeTablesIntegrationRtName01 string = '${environmentPrefix}-${toLower(environmentName)}-ca-rt-01'
 
 param dbsClientConsoleApplogsEndpointName string = 'DbsClientConsoleApplogsEndpoint'
 
@@ -60,11 +39,6 @@ param tags object = {
 }
 
 var lowercaseEnvironmentName = toLower(environmentName)
-
-resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' existing = {
-  scope: resourceGroup(containerAppEnvironmentResourceGroupName)
-  name: containerAppEnvironmentVnetName
-}
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-06-01' existing = {
   scope: resourceGroup(logAnalyticsWorkspaceResourceGroupName)
@@ -158,238 +132,6 @@ resource vm 'Microsoft.Compute/virtualMachines@2022-03-01' = {
   }
 }
 
-resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
-  name: virtualNetworksVnetfwName
-  location: location
-  tags: tags
-  properties: {
-    addressSpace: {
-      addressPrefixes: [
-        '192.168.2.0/23'
-      ]
-    }
-    encryption: {
-      enabled: false
-      enforcement: 'AllowUnencrypted'
-    }
-    privateEndpointVNetPolicies: 'Disabled'
-    subnets: [
-      {
-        name: 'AzureFirewallSubnet'
-        properties: {
-          addressPrefixes: [
-            '192.168.2.0/25'
-          ]
-          privateEndpointNetworkPolicies: 'Disabled'
-          privateLinkServiceNetworkPolicies: 'Enabled'
-        }
-        type: 'Microsoft.Network/virtualNetworks/subnets'
-      }
-    ]
-    enableDdosProtection: false
-  }
-}
-
-resource caeToFirewallPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2020-05-01' = {
-  name: '${caeVnet.name}/peering-fw-01'
-  properties: {
-    allowVirtualNetworkAccess: true
-    allowForwardedTraffic: false
-    allowGatewayTransit: false
-    useRemoteGateways: false
-    remoteVirtualNetwork: {
-      id: firewallVirtualNetwork.id
-    }
-  }
-}
-
-resource publicIP 'Microsoft.Network/publicIPAddresses@2023-06-01' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-ca-pib-01'
-  location: location
-  sku: {
-    name: 'Standard'
-  }
-  tags: tags
-  properties: {
-    publicIPAllocationMethod: 'static'
-    publicIPAddressVersion: 'IPv4'
-  }
-}
-
-resource firewallPolicy 'Microsoft.Network/firewallPolicies@2022-01-01' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}-ca-fwp-01'
-  location: location
-  tags: tags
-  properties: {
-    sku: {
-      tier: 'Basic'
-    }
-    threatIntelMode: 'Alert'
-  }
-}
-
-resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
-  name: vnetFirewallName
-  location: location
-  tags: tags
-  properties: {
-    sku: {
-      name: 'AZFW_VNet'
-      tier: 'Basic'
-    }
-    threatIntelMode: 'Alert'
-    firewallPolicy: {
-      id: firewallPolicy.id
-    }
-    ipConfigurations: [
-      {
-        name: 'fw-ip-config-01'
-        properties: {
-          publicIPAddress: {
-            id: publicIP.id
-          }
-          subnet: {
-            id: '${firewallVirtualNetwork.id}/subnets/AzureFirewallSubnet'
-          }
-        }
-      }
-    ]
-  }
-}
-
-resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2022-01-01' = {
-  parent: firewallPolicy
-  name: 'DefaultApplicationRuleCollectionGroup'
-  properties: {
-    priority: 300
-    ruleCollections: [
-      {
-        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
-        action: {
-          type: 'Allow'
-        }
-        name: 'Global-rules-arc'
-        priority: 300
-        rules: [
-          {
-            ruleType: 'ApplicationRule'
-            name: 'global-rule-01'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              'int.api.service.nhs.uk'
-            ]
-            terminateTLS: false
-            sourceAddresses: [...caeVnet.properties.addressSpace.addressPrefixes]
-          }
-        ]
-      }
-      {
-        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
-        action: {
-          type: 'Allow'
-        }
-        rules: [
-          {
-            ruleType: 'ApplicationRule'
-            name: 'acr-allow'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              containerRegistryEndpoint
-            ]
-            terminateTLS: false
-            sourceAddresses: [
-              '192.168.0.0/24'
-            ]
-          }
-          {
-            ruleType: 'ApplicationRule'
-            name: 'Nuget'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              'api.nuget.org'
-            ]
-            terminateTLS: false
-            sourceAddresses: [
-              '192.168.0.0/24'
-            ]
-          }
-          {
-            ruleType: 'ApplicationRule'
-            name: 'kv'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              keyVaultEndpoint
-            ]
-            terminateTLS: false
-            sourceAddresses: [
-              '192.168.0.0/24'
-            ]
-          }
-          {
-            ruleType: 'ApplicationRule'
-            name: 'login'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              'login.microsoftonline.com'
-            ]
-            terminateTLS: false
-            sourceAddresses: [
-              '192.168.0.0/24'
-            ]
-          }
-        ]
-        name: 'allow-acr'
-        priority: 200
-      }
-    ]
-  }
-}
-
-resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
-  name: routeTablesIntegrationRtName01
-  location: location
-  tags: tags
-  properties: {
-    disableBgpRoutePropagation: false
-    routes: [
-      {
-        name: 'DefaultToFirewall'
-        properties: {
-          addressPrefix: '0.0.0.0/0'
-          nextHopType: 'VirtualAppliance'
-          nextHopIpAddress: firewall.properties.ipConfigurations[0].properties.privateIPAddress
-        }
-        type: 'Microsoft.Network/routeTables/routes'
-      }
-    ]
-  }
-}
-
 resource dbsClientConsoleApplogsEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2023-03-11' = {
   name: dbsClientConsoleApplogsEndpointName
   location: location
@@ -457,5 +199,3 @@ resource dbsClientConsoleAppLogsRule 'Microsoft.Insights/dataCollectionRules@202
 
 output vmName string = vm.name
 output clientVirtualNetworkName string = vnet.name
-output firewallName string = firewall.name
-output routeTableName string = routeTable.name

--- a/infra/modules/shared/container-app-environment.bicep
+++ b/infra/modules/shared/container-app-environment.bicep
@@ -25,6 +25,9 @@ param privateEndpointSubnetAddressPrefix string = ''
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@description('Resource ID of the route table associated with the container app environment subnet. Required so that all egress traffic flows through the firewall.')
+param routeTableId string
+
 @description('The Log Analytics workspace name used by the container app environment')
 param logAnalyticsWorkspaceName string
 
@@ -59,6 +62,9 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
         name: containerAppEnvironmentSubnetName
         properties: {
           addressPrefix: containerAppEnvSubnet
+          routeTable: {
+            id: routeTableId
+          }
           delegations: [
             {
               name: 'Microsoft.App.environments'

--- a/infra/modules/shared/container-app-environment.bicep
+++ b/infra/modules/shared/container-app-environment.bicep
@@ -25,8 +25,9 @@ param privateEndpointSubnetAddressPrefix string = ''
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
-@description('Resource ID of the route table associated with the container app environment subnet. Required so that all egress traffic flows through the firewall.')
-param routeTableId string
+// Backwards compatibility with legacy in app-host/infra 
+@description('Optional resource ID of the route table to attach to the container app environment subnet so that egress traffic flows through a firewall. When empty, no route table is attached.')
+param routeTableId string = ''
 
 @description('The Log Analytics workspace name used by the container app environment')
 param logAnalyticsWorkspaceName string
@@ -35,6 +36,11 @@ var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}
 var dashboardComponentName = '${empty(stackNameSuffix) ? 'aspire' : toLower(stackNameSuffix)}-dashboard-01'
 var containerAppEnvironmentSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-cae-01'
 var privateEndpointSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
+var caeSubnetRouteTable = empty(routeTableId) ? {} : {
+  routeTable: {
+    id: routeTableId
+  }
+}
 var privateEndpointSubnets = empty(privateEndpointSubnetAddressPrefix) ? [] : [
   {
     name: privateEndpointSubnetName
@@ -60,11 +66,8 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
     subnets: concat([
       {
         name: containerAppEnvironmentSubnetName
-        properties: {
+        properties: union({
           addressPrefix: containerAppEnvSubnet
-          routeTable: {
-            id: routeTableId
-          }
           delegations: [
             {
               name: 'Microsoft.App.environments'
@@ -73,7 +76,7 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
               }
             }
           ]
-        }
+        }, caeSubnetRouteTable)
       }
     ], privateEndpointSubnets)
   }

--- a/infra/modules/shared/container-app-environment.bicep
+++ b/infra/modules/shared/container-app-environment.bicep
@@ -13,8 +13,11 @@ param stackNameSuffix string = ''
 @description('container app managed environment number')
 param containerAppManagedEnvironmentNumber string
 
-@description('The address prefix for the virtual network')
-param containerAppVnet string
+@description('The name of the virtual network that contains the container app environment subnet. When empty, the module creates the virtual network for backwards compatibility.')
+param virtualNetworkName string = ''
+
+@description('The address prefix for the virtual network. Required when virtualNetworkName is empty.')
+param containerAppVnet string = ''
 
 @description('Container App environment subnet')
 param containerAppEnvSubnet string
@@ -25,7 +28,7 @@ param privateEndpointSubnetAddressPrefix string = ''
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
-// Backwards compatibility with legacy in app-host/infra 
+// Backwards compatibility with legacy in app-host/infra
 @description('Optional resource ID of the route table to attach to the container app environment subnet so that egress traffic flows through a firewall. When empty, no route table is attached.')
 param routeTableId string = ''
 
@@ -34,6 +37,7 @@ param logAnalyticsWorkspaceName string
 
 var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
 var dashboardComponentName = '${empty(stackNameSuffix) ? 'aspire' : toLower(stackNameSuffix)}-dashboard-01'
+var caeVnetName = empty(virtualNetworkName) ? '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnet-cae-01' : virtualNetworkName
 var containerAppEnvironmentSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-cae-01'
 var privateEndpointSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
 var caeSubnetRouteTable = empty(routeTableId) ? {} : {
@@ -41,21 +45,13 @@ var caeSubnetRouteTable = empty(routeTableId) ? {} : {
     id: routeTableId
   }
 }
-var privateEndpointSubnets = empty(privateEndpointSubnetAddressPrefix) ? [] : [
-  {
-    name: privateEndpointSubnetName
-    properties: {
-      addressPrefix: privateEndpointSubnetAddressPrefix
-    }
-  }
-]
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2022-10-01' existing = {
   name: logAnalyticsWorkspaceName
 }
 
-resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
-  name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnet-cae-01'
+resource caeVnet 'Microsoft.Network/virtualNetworks@2024-05-01' = if (empty(virtualNetworkName)) {
+  name: caeVnetName
   location: location
   properties: {
     addressSpace: {
@@ -63,23 +59,37 @@ resource caeVnet 'Microsoft.Network/virtualNetworks@2022-07-01' = {
         containerAppVnet
       ]
     }
-    subnets: concat([
-      {
-        name: containerAppEnvironmentSubnetName
-        properties: union({
-          addressPrefix: containerAppEnvSubnet
-          delegations: [
-            {
-              name: 'Microsoft.App.environments'
-              properties: {
-                serviceName: 'Microsoft.App/environments'
-              }
-            }
-          ]
-        }, caeSubnetRouteTable)
-      }
-    ], privateEndpointSubnets)
   }
+}
+
+resource containerAppEnvironmentSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  #disable-next-line use-parent-property
+  name: '${caeVnetName}/${containerAppEnvironmentSubnetName}'
+  properties: union({
+    addressPrefix: containerAppEnvSubnet
+    delegations: [
+      {
+        name: 'Microsoft.App.environments'
+        properties: {
+          serviceName: 'Microsoft.App/environments'
+        }
+      }
+    ]
+  }, caeSubnetRouteTable)
+  dependsOn: [
+    caeVnet
+  ]
+}
+
+resource privateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = if (!empty(privateEndpointSubnetAddressPrefix)) {
+  #disable-next-line use-parent-property
+  name: '${caeVnetName}/${privateEndpointSubnetName}'
+  properties: {
+    addressPrefix: privateEndpointSubnetAddressPrefix
+  }
+  dependsOn: [
+    caeVnet
+  ]
 }
 
 resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-preview' = {
@@ -109,7 +119,7 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-p
     }
     publicNetworkAccess: 'Disabled'
     vnetConfiguration: {
-      infrastructureSubnetId: '${caeVnet.id}/subnets/${containerAppEnvironmentSubnetName}'
+      infrastructureSubnetId: containerAppEnvironmentSubnet.id
       internal: true
     }
   }
@@ -125,6 +135,6 @@ resource containerAppEnvironment 'Microsoft.App/managedEnvironments@2024-10-02-p
 output name string = containerAppEnvironment.name
 output id string = containerAppEnvironment.id
 output defaultDomain string = containerAppEnvironment.properties.defaultDomain
-output virtualNetworkName string = caeVnet.name
-output virtualNetworkId string = caeVnet.id
-output privateEndpointSubnetId string = empty(privateEndpointSubnetAddressPrefix) ? '' : '${caeVnet.id}/subnets/${privateEndpointSubnetName}'
+output virtualNetworkName string = caeVnetName
+output virtualNetworkId string = resourceId('Microsoft.Network/virtualNetworks', caeVnetName)
+output privateEndpointSubnetId string = empty(privateEndpointSubnetAddressPrefix) ? '' : resourceId('Microsoft.Network/virtualNetworks/subnets', caeVnetName, privateEndpointSubnetName)

--- a/infra/modules/shared/container-app-network.bicep
+++ b/infra/modules/shared/container-app-network.bicep
@@ -1,0 +1,48 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('The lowercase environment name used for resource naming')
+param lowercaseEnvironmentName string
+
+@description('Short stack-specific suffix used to avoid cross-stack name collisions.')
+param stackNameSuffix string = ''
+
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@description('Optional private endpoint subnet address prefix')
+param privateEndpointSubnetAddressPrefix string = ''
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
+var privateEndpointSubnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-subnet-pe-01'
+
+resource caeVnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnet-cae-01'
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        containerAppVnet
+      ]
+    }
+  }
+}
+
+resource privateEndpointSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = if (!empty(privateEndpointSubnetAddressPrefix)) {
+  parent: caeVnet
+  name: privateEndpointSubnetName
+  properties: {
+    addressPrefix: privateEndpointSubnetAddressPrefix
+  }
+}
+
+output virtualNetworkName string = caeVnet.name
+output virtualNetworkId string = caeVnet.id
+output privateEndpointSubnetId string = empty(privateEndpointSubnetAddressPrefix) ? '' : '${caeVnet.id}/subnets/${privateEndpointSubnetName}'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -1,0 +1,243 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('Name of the deployment environment')
+param environmentName string
+
+@description('The prefix used for all deployed resources')
+param environmentPrefix string
+
+@description('Short stack-specific suffix used to avoid cross-stack name collisions.')
+param stackNameSuffix string = ''
+
+@description('The login server for the container registry to allow through the firewall')
+param containerRegistryEndpoint string
+
+@description('The name of the shared Key Vault')
+param keyVaultName string
+
+@description('The Key Vault FQDN allowed through the firewall')
+#disable-next-line no-hardcoded-env-urls
+param keyVaultEndpoint string = '${keyVaultName}.vault.azure.net'
+
+@description('The address prefix for the firewall virtual network')
+param firewallVnetAddressPrefix string = '192.168.4.0/23'
+
+@description('The address prefix for the Azure Firewall subnet')
+param firewallSubnetAddressPrefix string = '192.168.4.0/25'
+
+@description('The address spaces of the CAE virtual network (used as source address ranges in the firewall policy)')
+param caeVnetAddressPrefixes array
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+var lowercaseEnvironmentName = toLower(environmentName)
+var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
+
+var firewallVnetName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnetfw-01'
+var firewallName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-vnetfw-Firewall'
+var firewallPolicyName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-fwp-01'
+var publicIpName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-pib-01'
+var routeTableName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-rt-01'
+
+resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: firewallVnetName
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        firewallVnetAddressPrefix
+      ]
+    }
+    encryption: {
+      enabled: false
+      enforcement: 'AllowUnencrypted'
+    }
+    privateEndpointVNetPolicies: 'Disabled'
+    subnets: [
+      {
+        name: 'AzureFirewallSubnet'
+        properties: {
+          addressPrefix: firewallSubnetAddressPrefix
+          privateEndpointNetworkPolicies: 'Disabled'
+          privateLinkServiceNetworkPolicies: 'Enabled'
+        }
+        type: 'Microsoft.Network/virtualNetworks/subnets'
+      }
+    ]
+    enableDdosProtection: false
+  }
+}
+
+resource publicIP 'Microsoft.Network/publicIPAddresses@2023-06-01' = {
+  name: publicIpName
+  location: location
+  sku: {
+    name: 'Standard'
+  }
+  tags: tags
+  properties: {
+    publicIPAllocationMethod: 'Static'
+    publicIPAddressVersion: 'IPv4'
+  }
+}
+
+resource firewallPolicy 'Microsoft.Network/firewallPolicies@2022-01-01' = {
+  name: firewallPolicyName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      tier: 'Basic'
+    }
+    threatIntelMode: 'Alert'
+  }
+}
+
+resource firewall 'Microsoft.Network/azureFirewalls@2024-05-01' = {
+  name: firewallName
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'AZFW_VNet'
+      tier: 'Basic'
+    }
+    threatIntelMode: 'Alert'
+    firewallPolicy: {
+      id: firewallPolicy.id
+    }
+    ipConfigurations: [
+      {
+        name: 'fw-ip-config-01'
+        properties: {
+          publicIPAddress: {
+            id: publicIP.id
+          }
+          subnet: {
+            id: '${firewallVirtualNetwork.id}/subnets/AzureFirewallSubnet'
+          }
+        }
+      }
+    ]
+  }
+}
+
+resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2022-01-01' = {
+  parent: firewallPolicy
+  name: 'DefaultApplicationRuleCollectionGroup'
+  properties: {
+    priority: 300
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        name: 'Global-rules-arc'
+        priority: 300
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'nhs-api-allow'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            targetFqdns: [
+              'int.api.service.nhs.uk'
+              'api.service.nhs.uk'
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+        ]
+      }
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        name: 'allow-system-arc'
+        priority: 200
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'acr-allow'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            targetFqdns: [
+              containerRegistryEndpoint
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'kv-allow'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            targetFqdns: [
+              keyVaultEndpoint
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+          {
+            ruleType: 'ApplicationRule'
+            name: 'login-allow'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            targetFqdns: [
+              'login.microsoftonline.com'
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+        ]
+      }
+    ]
+  }
+}
+
+resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
+  name: routeTableName
+  location: location
+  tags: tags
+  properties: {
+    disableBgpRoutePropagation: false
+    routes: [
+      {
+        name: 'DefaultToFirewall'
+        properties: {
+          addressPrefix: '0.0.0.0/0'
+          nextHopType: 'VirtualAppliance'
+          nextHopIpAddress: firewall.properties.ipConfigurations[0].properties.privateIPAddress
+        }
+        type: 'Microsoft.Network/routeTables/routes'
+      }
+    ]
+  }
+}
+
+output routeTableId string = routeTable.id
+output routeTableName string = routeTable.name
+output firewallPrivateIp string = firewall.properties.ipConfigurations[0].properties.privateIPAddress
+output firewallVnetName string = firewallVirtualNetwork.name
+output firewallVnetId string = firewallVirtualNetwork.id

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -41,6 +41,22 @@ var firewallPolicyName = '${environmentPrefix}-${lowercaseEnvironmentName}${stac
 var publicIpName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-pib-01'
 var routeTableName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-rt-01'
 
+var systemFqdnRules = [
+  {
+    name: 'acr-allow'
+    fqdn: containerRegistryEndpoint
+  }
+  {
+    name: 'kv-allow'
+    fqdn: keyVaultEndpoint
+  }
+  {
+    name: 'login-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'login.microsoftonline.com'
+  }
+]
+
 resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: firewallVnetName
   location: location
@@ -164,53 +180,21 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         }
         name: 'allow-system-arc'
         priority: 200
-        rules: [
-          {
-            ruleType: 'ApplicationRule'
-            name: 'acr-allow'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              containerRegistryEndpoint
-            ]
-            terminateTLS: false
-            sourceAddresses: caeVnetAddressPrefixes
-          }
-          {
-            ruleType: 'ApplicationRule'
-            name: 'kv-allow'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              keyVaultEndpoint
-            ]
-            terminateTLS: false
-            sourceAddresses: caeVnetAddressPrefixes
-          }
-          {
-            ruleType: 'ApplicationRule'
-            name: 'login-allow'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            targetFqdns: [
-              'login.microsoftonline.com'
-            ]
-            terminateTLS: false
-            sourceAddresses: caeVnetAddressPrefixes
-          }
-        ]
+        rules: [for rule in systemFqdnRules: {
+          ruleType: 'ApplicationRule'
+          name: rule.name
+          protocols: [
+            {
+              protocolType: 'Https'
+              port: 443
+            }
+          ]
+          targetFqdns: [
+            rule.fqdn
+          ]
+          terminateTLS: false
+          sourceAddresses: caeVnetAddressPrefixes
+        }]
       }
     ]
   }
@@ -238,6 +222,7 @@ resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
 
 output routeTableId string = routeTable.id
 output routeTableName string = routeTable.name
+output firewallName string = firewall.name
 output firewallPrivateIp string = firewall.properties.ipConfigurations[0].properties.privateIPAddress
 output firewallVnetName string = firewallVirtualNetwork.name
 output firewallVnetId string = firewallVirtualNetwork.id

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -20,6 +20,12 @@ param keyVaultName string
 #disable-next-line no-hardcoded-env-urls
 param keyVaultEndpoint string = '${keyVaultName}.vault.azure.net'
 
+@description('The NHS API FQDNs allowed through the firewall for this environment')
+param allowedNhsFqdns array
+
+@description('Resource ID of the Log Analytics workspace that receives firewall diagnostic logs and metrics')
+param logAnalyticsWorkspaceId string
+
 @description('The address prefix for the firewall virtual network')
 param firewallVnetAddressPrefix string = '192.168.4.0/23'
 
@@ -40,8 +46,29 @@ var firewallName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameT
 var firewallPolicyName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-fwp-01'
 var publicIpName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-pib-01'
 var routeTableName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-rt-01'
+var containerAppRegion = toLower(replace(location, ' ', ''))
 
-var systemFqdnRules = [
+var platformFqdnRules = [
+  {
+    name: 'mcr-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'mcr.microsoft.com'
+  }
+  {
+    name: 'mcr-data-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '*.data.mcr.microsoft.com'
+  }
+  {
+    name: 'aks-packages-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'packages.aks.azure.com'
+  }
+  {
+    name: 'aks-mirror-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'acs-mirror.azureedge.net'
+  }
   {
     name: 'acr-allow'
     fqdn: containerRegistryEndpoint
@@ -60,7 +87,32 @@ var systemFqdnRules = [
   {
     name: 'login-allow'
     #disable-next-line no-hardcoded-env-urls
+    fqdn: 'login.microsoft.com'
+  }
+  {
+    name: 'login-online-allow'
+    #disable-next-line no-hardcoded-env-urls
     fqdn: 'login.microsoftonline.com'
+  }
+  {
+    name: 'login-online-wildcard-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '*.login.microsoftonline.com'
+  }
+  {
+    name: 'login-wildcard-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '*.login.microsoft.com'
+  }
+  {
+    name: 'managed-identity-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '*.identity.azure.net'
+  }
+  {
+    name: 'aspire-dashboard-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '${containerAppRegion}.ext.azurecontainerapps.dev'
   }
 ]
 
@@ -172,8 +224,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
               }
             ]
             targetFqdns: [
-              'int.api.service.nhs.uk'
-              'api.service.nhs.uk'
+              for fqdn in allowedNhsFqdns: fqdn
             ]
             terminateTLS: false
             sourceAddresses: caeVnetAddressPrefixes
@@ -187,7 +238,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         }
         name: 'allow-system-arc'
         priority: 200
-        rules: [for rule in systemFqdnRules: {
+        rules: [for rule in platformFqdnRules: {
           ruleType: 'ApplicationRule'
           name: rule.name
           protocols: [
@@ -232,6 +283,41 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
   }
 }
 
+resource networkRuleCollectionGroup 'Microsoft.Network/firewallPolicies/ruleCollectionGroups@2022-01-01' = {
+  parent: firewallPolicy
+  name: 'DefaultNetworkRuleCollectionGroup'
+  properties: {
+    priority: 400
+    ruleCollections: [
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        name: 'allow-platform-network-nrc'
+        priority: 200
+        rules: [
+          {
+            ruleType: 'NetworkRule'
+            name: 'azure-dns-allow'
+            ipProtocols: [
+              'TCP'
+              'UDP'
+            ]
+            sourceAddresses: caeVnetAddressPrefixes
+            destinationAddresses: [
+              '168.63.129.16'
+            ]
+            destinationPorts: [
+              '53'
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+
 resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
   name: routeTableName
   location: location
@@ -247,6 +333,26 @@ resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
           nextHopIpAddress: firewall.properties.ipConfigurations[0].properties.privateIPAddress
         }
         type: 'Microsoft.Network/routeTables/routes'
+      }
+    ]
+  }
+}
+
+resource firewallDiagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: '${firewallName}-diagnostics'
+  scope: firewall
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        categoryGroup: 'AllLogs'
+        enabled: true
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
       }
     ]
   }

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -50,6 +50,9 @@ var firewallPolicyName = '${environmentPrefix}-${lowercaseEnvironmentName}${stac
 var publicIpName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-pib-01'
 var routeTableName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-rt-01'
 var containerAppRegion = toLower(replace(location, ' ', ''))
+var containerRegistryName = replace(toLower(containerRegistryEndpoint), '.azurecr.io', '')
+#disable-next-line no-hardcoded-env-urls
+var containerRegistryDataEndpoint = '${containerRegistryName}.${containerAppRegion}.data.azurecr.io'
 
 var platformFqdnRules = [
   {
@@ -77,11 +80,8 @@ var platformFqdnRules = [
     fqdn: containerRegistryEndpoint
   }
   {
-    // Basic-tier ACR serves image layers from shared Azure Storage; narrowing
-    // this requires upgrading ACR to Premium with dedicated data endpoints.
-    name: 'acr-blob-allow'
-    #disable-next-line no-hardcoded-env-urls
-    fqdn: '*.blob.core.windows.net'
+    name: 'acr-data-allow'
+    fqdn: containerRegistryDataEndpoint
   }
   {
     name: 'login-allow'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -260,31 +260,6 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
           }
         ]
       }
-      {
-        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
-        action: {
-          type: 'Allow'
-        }
-        name: 'allow-azure-monitor-arc'
-        priority: 250
-        rules: [
-          {
-            ruleType: 'ApplicationRule'
-            name: 'azure-monitor-allow'
-            protocols: [
-              {
-                protocolType: 'Https'
-                port: 443
-              }
-            ]
-            fqdnTags: [
-              'AzureMonitor'
-            ]
-            terminateTLS: false
-            sourceAddresses: caeVnetAddressPrefixes
-          }
-        ]
-      }
     ]
   }
 }

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -33,10 +33,10 @@ param allowedNhsFqdns array
 param logAnalyticsWorkspaceId string
 
 @description('The address prefix for the firewall virtual network')
-param firewallVnetAddressPrefix string = '192.168.4.0/23'
+param firewallVnetAddressPrefix string = '192.168.2.0/23'
 
 @description('The address prefix for the Azure Firewall subnet')
-param firewallSubnetAddressPrefix string = '192.168.4.0/25'
+param firewallSubnetAddressPrefix string = '192.168.2.0/25'
 
 @description('The address spaces of the CAE virtual network (used as source address ranges in the firewall policy)')
 param caeVnetAddressPrefixes array

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -33,10 +33,10 @@ param allowedNhsFqdns array
 param logAnalyticsWorkspaceId string
 
 @description('The address prefix for the firewall virtual network')
-param firewallVnetAddressPrefix string = '192.168.2.0/23'
+param firewallVnetAddressPrefix string = '192.168.1.0/24'
 
 @description('The address prefix for the Azure Firewall subnet')
-param firewallSubnetAddressPrefix string = '192.168.2.0/25'
+param firewallSubnetAddressPrefix string = '192.168.1.0/24'
 
 @description('The address spaces of the CAE virtual network (used as source address ranges in the firewall policy)')
 param caeVnetAddressPrefixes array
@@ -118,12 +118,14 @@ var containerRegistryDataEndpointFqdnRules = [
   }
 ]
 
-var keyVaultFqdnRules = allowKeyVaultPublicEgress ? [
-  {
-    name: 'kv-allow'
-    fqdn: keyVaultEndpoint
-  }
-] : []
+var keyVaultFqdnRules = allowKeyVaultPublicEgress
+  ? [
+      {
+        name: 'kv-allow'
+        fqdn: keyVaultEndpoint
+      }
+    ]
+  : []
 
 var systemFqdnRules = concat(platformFqdnRules, containerRegistryDataEndpointFqdnRules, keyVaultFqdnRules)
 
@@ -234,9 +236,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
                 port: 443
               }
             ]
-            targetFqdns: [
-              for fqdn in allowedNhsFqdns: fqdn
-            ]
+            targetFqdns: [for fqdn in allowedNhsFqdns: fqdn]
             terminateTLS: false
             sourceAddresses: caeVnetAddressPrefixes
           }
@@ -249,21 +249,23 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         }
         name: 'allow-system-arc'
         priority: 200
-        rules: [for rule in systemFqdnRules: {
-          ruleType: 'ApplicationRule'
-          name: rule.name
-          protocols: [
-            {
-              protocolType: 'Https'
-              port: 443
-            }
-          ]
-          targetFqdns: [
-            rule.fqdn
-          ]
-          terminateTLS: false
-          sourceAddresses: caeVnetAddressPrefixes
-        }]
+        rules: [
+          for rule in systemFqdnRules: {
+            ruleType: 'ApplicationRule'
+            name: rule.name
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            targetFqdns: [
+              rule.fqdn
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+        ]
       }
       {
         ruleCollectionType: 'FirewallPolicyFilterRuleCollection'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -104,11 +104,6 @@ var platformFqdnRules = [
     #disable-next-line no-hardcoded-env-urls
     fqdn: '*.identity.azure.net'
   }
-  {
-    name: 'aspire-dashboard-allow'
-    #disable-next-line no-hardcoded-env-urls
-    fqdn: '${containerAppRegion}.ext.azurecontainerapps.dev'
-  }
 ]
 
 var containerRegistryDataEndpointFqdnRules = [

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -13,6 +13,9 @@ param stackNameSuffix string = ''
 @description('The login server for the container registry to allow through the firewall')
 param containerRegistryEndpoint string
 
+@description('The dedicated data endpoint host names for the Premium container registry to allow through the firewall')
+param containerRegistryDataEndpointHostNames array
+
 @description('The name of the shared Key Vault')
 param keyVaultName string
 
@@ -50,9 +53,6 @@ var firewallPolicyName = '${environmentPrefix}-${lowercaseEnvironmentName}${stac
 var publicIpName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-pib-01'
 var routeTableName = '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-rt-01'
 var containerAppRegion = toLower(replace(location, ' ', ''))
-var containerRegistryName = replace(toLower(containerRegistryEndpoint), '.azurecr.io', '')
-#disable-next-line no-hardcoded-env-urls
-var containerRegistryDataEndpoint = '${containerRegistryName}.${containerAppRegion}.data.azurecr.io'
 
 var platformFqdnRules = [
   {
@@ -78,10 +78,6 @@ var platformFqdnRules = [
   {
     name: 'acr-allow'
     fqdn: containerRegistryEndpoint
-  }
-  {
-    name: 'acr-data-allow'
-    fqdn: containerRegistryDataEndpoint
   }
   {
     name: 'login-allow'
@@ -115,6 +111,13 @@ var platformFqdnRules = [
   }
 ]
 
+var containerRegistryDataEndpointFqdnRules = [
+  for (hostName, index) in containerRegistryDataEndpointHostNames: {
+    name: index == 0 ? 'acr-data-allow' : 'acr-data-${index + 1}-allow'
+    fqdn: hostName
+  }
+]
+
 var keyVaultFqdnRules = allowKeyVaultPublicEgress ? [
   {
     name: 'kv-allow'
@@ -122,7 +125,7 @@ var keyVaultFqdnRules = allowKeyVaultPublicEgress ? [
   }
 ] : []
 
-var systemFqdnRules = concat(platformFqdnRules, keyVaultFqdnRules)
+var systemFqdnRules = concat(platformFqdnRules, containerRegistryDataEndpointFqdnRules, keyVaultFqdnRules)
 
 resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: firewallVnetName

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -144,8 +144,6 @@ resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' =
         name: 'AzureFirewallSubnet'
         properties: {
           addressPrefix: firewallSubnetAddressPrefix
-          privateEndpointNetworkPolicies: 'Disabled'
-          privateLinkServiceNetworkPolicies: 'Enabled'
         }
         type: 'Microsoft.Network/virtualNetworks/subnets'
       }

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -217,7 +217,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         action: {
           type: 'Allow'
         }
-        name: 'Global-rules-arc'
+        name: 'allow-nhs-fqdns'
         priority: 300
         rules: [
           {
@@ -240,7 +240,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         action: {
           type: 'Allow'
         }
-        name: 'allow-system-arc'
+        name: 'allow-sui-system-fqds'
         priority: 200
         rules: [
           for rule in systemFqdnRules: {

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -20,6 +20,9 @@ param keyVaultName string
 #disable-next-line no-hardcoded-env-urls
 param keyVaultEndpoint string = '${keyVaultName}.vault.azure.net'
 
+@description('Whether to allow public Key Vault egress through the firewall. Set to false when the stack uses a Key Vault private endpoint with private DNS.')
+param allowKeyVaultPublicEgress bool = true
+
 @description('The NHS API FQDNs allowed through the firewall for this environment')
 param allowedNhsFqdns array
 
@@ -81,10 +84,6 @@ var platformFqdnRules = [
     fqdn: '*.blob.core.windows.net'
   }
   {
-    name: 'kv-allow'
-    fqdn: keyVaultEndpoint
-  }
-  {
     name: 'login-allow'
     #disable-next-line no-hardcoded-env-urls
     fqdn: 'login.microsoft.com'
@@ -115,6 +114,15 @@ var platformFqdnRules = [
     fqdn: '${containerAppRegion}.ext.azurecontainerapps.dev'
   }
 ]
+
+var keyVaultFqdnRules = allowKeyVaultPublicEgress ? [
+  {
+    name: 'kv-allow'
+    fqdn: keyVaultEndpoint
+  }
+] : []
+
+var systemFqdnRules = concat(platformFqdnRules, keyVaultFqdnRules)
 
 resource firewallVirtualNetwork 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: firewallVnetName
@@ -238,7 +246,7 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
         }
         name: 'allow-system-arc'
         priority: 200
-        rules: [for rule in platformFqdnRules: {
+        rules: [for rule in systemFqdnRules: {
           ruleType: 'ApplicationRule'
           name: rule.name
           protocols: [

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -304,7 +304,7 @@ resource routeTable 'Microsoft.Network/routeTables@2024-05-01' = {
   location: location
   tags: tags
   properties: {
-    disableBgpRoutePropagation: false
+    disableBgpRoutePropagation: true
     routes: [
       {
         name: 'DefaultToFirewall'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -47,6 +47,13 @@ var systemFqdnRules = [
     fqdn: containerRegistryEndpoint
   }
   {
+    // Basic-tier ACR serves image layers from shared Azure Storage; narrowing
+    // this requires upgrading ACR to Premium with dedicated data endpoints.
+    name: 'acr-blob-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: '*.blob.core.windows.net'
+  }
+  {
     name: 'kv-allow'
     fqdn: keyVaultEndpoint
   }
@@ -195,6 +202,31 @@ resource applicationRuleCollectionGroup 'Microsoft.Network/firewallPolicies/rule
           terminateTLS: false
           sourceAddresses: caeVnetAddressPrefixes
         }]
+      }
+      {
+        ruleCollectionType: 'FirewallPolicyFilterRuleCollection'
+        action: {
+          type: 'Allow'
+        }
+        name: 'allow-azure-monitor-arc'
+        priority: 250
+        rules: [
+          {
+            ruleType: 'ApplicationRule'
+            name: 'azure-monitor-allow'
+            protocols: [
+              {
+                protocolType: 'Https'
+                port: 443
+              }
+            ]
+            fqdnTags: [
+              'AzureMonitor'
+            ]
+            terminateTLS: false
+            sourceAddresses: caeVnetAddressPrefixes
+          }
+        ]
       }
     ]
   }

--- a/infra/modules/shared/virtual-network-peering.bicep
+++ b/infra/modules/shared/virtual-network-peering.bicep
@@ -30,8 +30,6 @@ resource vnet1ToVnet2Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPe
   properties: {
     allowVirtualNetworkAccess: true
     allowForwardedTraffic: vnet1AllowForwardedTraffic
-    allowGatewayTransit: false
-    useRemoteGateways: false
     remoteVirtualNetwork: {
       id: vnet2.id
     }
@@ -44,8 +42,6 @@ resource vnet2ToVnet1Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPe
   properties: {
     allowVirtualNetworkAccess: true
     allowForwardedTraffic: vnet2AllowForwardedTraffic
-    allowGatewayTransit: false
-    useRemoteGateways: false
     remoteVirtualNetwork: {
       id: vnet1.id
     }

--- a/infra/modules/shared/virtual-network-peering.bicep
+++ b/infra/modules/shared/virtual-network-peering.bicep
@@ -1,0 +1,47 @@
+@description('The name of the first virtual network')
+param vnet1Name string
+
+@description('The name of the second virtual network')
+param vnet2Name string
+
+@description('The name of the peering created on vnet1 (pointing at vnet2)')
+param vnet1ToVnet2PeeringName string = 'peering-to-${vnet2Name}'
+
+@description('The name of the peering created on vnet2 (pointing at vnet1)')
+param vnet2ToVnet1PeeringName string = 'peering-to-${vnet1Name}'
+
+resource vnet1 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
+  name: vnet1Name
+}
+
+resource vnet2 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
+  name: vnet2Name
+}
+
+resource vnet1ToVnet2Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-05-01' = {
+  parent: vnet1
+  name: vnet1ToVnet2PeeringName
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: vnet2.id
+    }
+  }
+}
+
+resource vnet2ToVnet1Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2024-05-01' = {
+  parent: vnet2
+  name: vnet2ToVnet1PeeringName
+  properties: {
+    allowVirtualNetworkAccess: true
+    allowForwardedTraffic: false
+    allowGatewayTransit: false
+    useRemoteGateways: false
+    remoteVirtualNetwork: {
+      id: vnet1.id
+    }
+  }
+}

--- a/infra/modules/shared/virtual-network-peering.bicep
+++ b/infra/modules/shared/virtual-network-peering.bicep
@@ -10,6 +10,12 @@ param vnet1ToVnet2PeeringName string = 'peering-to-${vnet2Name}'
 @description('The name of the peering created on vnet2 (pointing at vnet1)')
 param vnet2ToVnet1PeeringName string = 'peering-to-${vnet1Name}'
 
+@description('Whether vnet1 can receive forwarded traffic from vnet2')
+param vnet1AllowForwardedTraffic bool = false
+
+@description('Whether vnet2 can receive forwarded traffic from vnet1')
+param vnet2AllowForwardedTraffic bool = false
+
 resource vnet1 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
   name: vnet1Name
 }
@@ -23,7 +29,7 @@ resource vnet1ToVnet2Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPe
   name: vnet1ToVnet2PeeringName
   properties: {
     allowVirtualNetworkAccess: true
-    allowForwardedTraffic: false
+    allowForwardedTraffic: vnet1AllowForwardedTraffic
     allowGatewayTransit: false
     useRemoteGateways: false
     remoteVirtualNetwork: {
@@ -37,7 +43,7 @@ resource vnet2ToVnet1Peering 'Microsoft.Network/virtualNetworks/virtualNetworkPe
   name: vnet2ToVnet1PeeringName
   properties: {
     allowVirtualNetworkAccess: true
-    allowForwardedTraffic: false
+    allowForwardedTraffic: vnet2AllowForwardedTraffic
     allowGatewayTransit: false
     useRemoteGateways: false
     remoteVirtualNetwork: {

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -6,12 +6,17 @@ It composes the shared platform modules directly and adds the blob/queue storage
 
 Current scope:
 
-- shared platform resources for this stack
+- shared platform resources for this stack: identity, ACR, observability, monitoring, secrets, CAE, egress firewall, and VNet peering
 - storage account, either created by the stack or supplied as an existing account
 - blob containers for incoming, processed, and success files
 - primary and poison storage queues for the processing job contract
 - blob and queue private endpoints for the configured storage account
+- Event Grid system topic and blob-created subscription for incoming files
+- storage process ACA job triggered from the primary storage queue
 - matching API and external API container apps (internal ingress) deployed into the stack's CAE
+- Key Vault private endpoint for application secrets access
+
+Production egress allows `api.service.nhs.uk`. Non-production egress allows `int.api.service.nhs.uk`.
 
 `infra/stacks/blob-event-processor/subscription.bicep` is the subscription-scope entry point for this stack. By default, `resourceGroupMode=create` creates or updates the stack-owned `blob-event-processor` resource group and then deploys `main.bicep` into it.
 
@@ -23,6 +28,8 @@ It can also deploy into an existing resource group by setting:
 ## Storage modes
 
 The default storage mode is `storageAccountMode=create`. In this mode the stack creates the storage account, the blob/queue containers, and the blob/queue private endpoints and private DNS wiring.
+
+Created storage accounts use Standard LRS hot storage, disable blob public access, require TLS 1.2, and deny network access except for trusted Azure services.
 
 For client-provided storage, set:
 
@@ -89,15 +96,15 @@ Use `az deployment sub create` with the same parameters to deploy after reviewin
 
 If Azure CLI cannot write to the default local config directory, set `AZURE_CONFIG_DIR` to a writable temporary directory before running the commands.
 
-Follow up work:
-
-- Any further network/infrastructure needs for the processing job
-
 ## Unique to blob stack infrastructure
 
 ### ACA Job - Azure Container App job
 
-The ACA Job is the blob event driven processor that runs alongside the Matching, External API's in the same ACAE (Azure container apps environment)
+The ACA job is the blob event driven processor that runs alongside the Matching and External APIs in the same ACAE (Azure container apps environment).
+
+It uses the shared managed identity, pulls `sui-client-storage-process-job:<tag>` from the stack ACR, and is granted Storage Blob Data Contributor and Storage Queue Data Contributor when `includeRoleAssignments=true`.
+
+The job is configured with 2 vCPU, 4Gi memory, a 6 hour replica timeout, no automatic replica retries, and `StorageProcessJob__MaxDequeueCount=1`.
 
 ### Azure Storage blob and queues
 
@@ -107,7 +114,7 @@ Setup of Azure storage queues for the processing job contract, one for primary m
 
 ### Event Grid
 
-Setup of Event Grid, the EventGrid will trigger from a new blob file being created in the configured storage, it will then send a message to the configured storage queue.
+Setup of Event Grid. The Event Grid subscription listens for `Microsoft.Storage.BlobCreated` events under the `incoming` container and sends messages to the configured storage queue.
 
 ### KEDA
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -117,7 +117,6 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     keyVaultName: secrets.outputs.name
-    keyVaultEndpoint: '${secrets.outputs.name}.vault.azure.net'
     caeVnetAddressPrefixes: [
       containerAppVnet
     ]

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -134,6 +134,30 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
   }
 }
 
+module containerAppNetwork '../../modules/shared/container-app-network.bicep' = {
+  name: 'container-app-network'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    stackNameSuffix: stackNameSuffix
+    containerAppVnet: containerAppVnet
+    privateEndpointSubnetAddressPrefix: containerAppPeSubnet
+    tags: tags
+  }
+}
+
+module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
+  name: 'cae-firewall-peering'
+  params: {
+    vnet1Name: containerAppNetwork.outputs.virtualNetworkName
+    vnet2Name: egressFirewall.outputs.firewallVnetName
+    vnet1ToVnet2PeeringName: 'peering-fw-01'
+    vnet2ToVnet1PeeringName: 'peering-cae-01'
+    vnet1AllowForwardedTraffic: true
+  }
+}
+
 module containerAppEnvironment '../../modules/shared/container-app-environment.bicep' = {
   name: 'container-app-environment'
   params: {
@@ -142,24 +166,15 @@ module containerAppEnvironment '../../modules/shared/container-app-environment.b
     lowercaseEnvironmentName: lowercaseEnvironmentName
     stackNameSuffix: stackNameSuffix
     containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
-    containerAppVnet: containerAppVnet
+    virtualNetworkName: containerAppNetwork.outputs.virtualNetworkName
     containerAppEnvSubnet: containerAppEnvSubnet
-    privateEndpointSubnetAddressPrefix: containerAppPeSubnet
     tags: tags
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
     routeTableId: egressFirewall.outputs.routeTableId
   }
-}
-
-module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
-  name: 'cae-firewall-peering'
-  params: {
-    vnet1Name: containerAppEnvironment.outputs.virtualNetworkName
-    vnet2Name: egressFirewall.outputs.firewallVnetName
-    vnet1ToVnet2PeeringName: 'peering-fw-01'
-    vnet2ToVnet1PeeringName: 'peering-cae-01'
-    vnet1AllowForwardedTraffic: true
-  }
+  dependsOn: [
+    caeFirewallPeering
+  ]
 }
 
 module secrets '../../modules/shared/secrets.bicep' = {
@@ -178,8 +193,8 @@ module keyVaultPrivateEndpoint '../../modules/shared/key-vault-private-endpoint.
     location: location
     tags: tags
     keyVaultName: secrets.outputs.name
-    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
-    vnetId: containerAppEnvironment.outputs.virtualNetworkId
+    peSubnetId: containerAppNetwork.outputs.privateEndpointSubnetId
+    vnetId: containerAppNetwork.outputs.virtualNetworkId
   }
 }
 
@@ -200,8 +215,8 @@ module createdStorage '../../modules/blob-event-processor/storage.bicep' = if (s
     environmentPrefix: environmentPrefix
     lowercaseEnvironmentName: lowercaseEnvironmentName
     tags: tags
-    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
-    vnetId: containerAppEnvironment.outputs.virtualNetworkId
+    peSubnetId: containerAppNetwork.outputs.privateEndpointSubnetId
+    vnetId: containerAppNetwork.outputs.virtualNetworkId
   }
 }
 
@@ -210,8 +225,8 @@ module existingStorage '../../modules/blob-event-processor/existing-storage.bice
   params: {
     location: location
     tags: tags
-    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
-    vnetId: containerAppEnvironment.outputs.virtualNetworkId
+    peSubnetId: containerAppNetwork.outputs.privateEndpointSubnetId
+    vnetId: containerAppNetwork.outputs.virtualNetworkId
     storageAccountName: existingStorageAccountName
   }
 }

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -108,6 +108,23 @@ module observability '../../modules/shared/observability.bicep' = {
   }
 }
 
+module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
+  name: 'egress-firewall'
+  params: {
+    location: location
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    stackNameSuffix: stackNameSuffix
+    containerRegistryEndpoint: containerRegistry.outputs.endpoint
+    keyVaultName: secrets.outputs.name
+    keyVaultEndpoint: '${secrets.outputs.name}.vault.azure.net'
+    caeVnetAddressPrefixes: [
+      containerAppVnet
+    ]
+    tags: tags
+  }
+}
+
 module containerAppEnvironment '../../modules/shared/container-app-environment.bicep' = {
   name: 'container-app-environment'
   params: {
@@ -121,6 +138,17 @@ module containerAppEnvironment '../../modules/shared/container-app-environment.b
     privateEndpointSubnetAddressPrefix: containerAppPeSubnet
     tags: tags
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
+    routeTableId: egressFirewall.outputs.routeTableId
+  }
+}
+
+module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
+  name: 'cae-firewall-peering'
+  params: {
+    vnet1Name: containerAppEnvironment.outputs.virtualNetworkName
+    vnet2Name: egressFirewall.outputs.firewallVnetName
+    vnet1ToVnet2PeeringName: 'peering-fw-01'
+    vnet2ToVnet1PeeringName: 'peering-cae-01'
   }
 }
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -122,6 +122,7 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     environmentPrefix: environmentPrefix
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
+    containerRegistryDataEndpointHostNames: containerRegistry.outputs.dataEndpointHostNames
     keyVaultName: secrets.outputs.name
     allowKeyVaultPublicEgress: false
     allowedNhsFqdns: allowedNhsFqdns

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -63,6 +63,11 @@ param existingStorageAccountName string = ''
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
+var allowedNhsFqdns = lowercaseEnvironmentName == 'production' ? [
+  'api.service.nhs.uk'
+] : [
+  'int.api.service.nhs.uk'
+]
 
 var tags = {
   'azd-env-name': environmentName
@@ -117,6 +122,8 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     keyVaultName: secrets.outputs.name
+    allowedNhsFqdns: allowedNhsFqdns
+    logAnalyticsWorkspaceId: observability.outputs.workspaceId
     caeVnetAddressPrefixes: [
       containerAppVnet
     ]
@@ -148,6 +155,7 @@ module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' =
     vnet2Name: egressFirewall.outputs.firewallVnetName
     vnet1ToVnet2PeeringName: 'peering-fw-01'
     vnet2ToVnet1PeeringName: 'peering-cae-01'
+    vnet1AllowForwardedTraffic: true
   }
 }
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -123,6 +123,7 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     keyVaultName: secrets.outputs.name
+    allowKeyVaultPublicEgress: false
     allowedNhsFqdns: allowedNhsFqdns
     logAnalyticsWorkspaceId: observability.outputs.workspaceId
     caeVnetAddressPrefixes: [
@@ -292,6 +293,9 @@ module externalApi '../../modules/api-apps/external-api.bicep' = {
     tags: tags
     includeRoleAssignments: includeRoleAssignments
   }
+  dependsOn: [
+    keyVaultPrivateEndpoint
+  ]
 }
 
 output STACK_NAME string = 'blob-event-processor'

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -63,7 +63,8 @@ param existingStorageAccountName string = ''
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
-var allowedNhsFqdns = lowercaseEnvironmentName == 'production' ? [
+var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
+var allowedNhsFqdns = isProductionEnvironment ? [
   'api.service.nhs.uk'
 ] : [
   'int.api.service.nhs.uk'

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -48,6 +48,11 @@ param clientSubnetRange string = '192.168.0.128/26'
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'ca'
+var allowedNhsFqdns = lowercaseEnvironmentName == 'production' ? [
+  'api.service.nhs.uk'
+] : [
+  'int.api.service.nhs.uk'
+]
 var tags = {
   'azd-env-name': environmentName
   Product: 'SUI'
@@ -109,6 +114,8 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     keyVaultName: secrets.outputs.name
+    allowedNhsFqdns: allowedNhsFqdns
+    logAnalyticsWorkspaceId: observability.outputs.workspaceId
     caeVnetAddressPrefixes: [
       containerAppVnet
     ]
@@ -139,6 +146,7 @@ module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' =
     vnet2Name: egressFirewall.outputs.firewallVnetName
     vnet1ToVnet2PeeringName: 'peering-fw-shared-01'
     vnet2ToVnet1PeeringName: 'peering-cae-01'
+    vnet1AllowForwardedTraffic: true
   }
 }
 

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -48,7 +48,8 @@ param clientSubnetRange string = '192.168.0.128/26'
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'ca'
-var allowedNhsFqdns = lowercaseEnvironmentName == 'production' ? [
+var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
+var allowedNhsFqdns = isProductionEnvironment ? [
   'api.service.nhs.uk'
 ] : [
   'int.api.service.nhs.uk'

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -90,6 +90,33 @@ module observability '../../modules/shared/observability.bicep' = {
   }
 }
 
+module secrets '../../modules/shared/secrets.bicep' = {
+  name: 'secrets'
+  params: {
+    location: location
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    stackNameSuffix: stackNameSuffix
+  }
+}
+
+module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
+  name: 'egress-firewall'
+  params: {
+    location: location
+    environmentName: environmentName
+    environmentPrefix: environmentPrefix
+    stackNameSuffix: stackNameSuffix
+    containerRegistryEndpoint: containerRegistry.outputs.endpoint
+    keyVaultName: secrets.outputs.name
+    keyVaultEndpoint: '${secrets.outputs.name}.vault.azure.net'
+    caeVnetAddressPrefixes: [
+      containerAppVnet
+    ]
+    tags: tags
+  }
+}
+
 module containerAppEnvironment '../../modules/shared/container-app-environment.bicep' = {
   name: 'container-app-environment'
   params: {
@@ -102,16 +129,17 @@ module containerAppEnvironment '../../modules/shared/container-app-environment.b
     containerAppEnvSubnet: containerAppEnvSubnet
     tags: tags
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
+    routeTableId: egressFirewall.outputs.routeTableId
   }
 }
 
-module secrets '../../modules/shared/secrets.bicep' = {
-  name: 'secrets'
+module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
+  name: 'cae-firewall-peering'
   params: {
-    location: location
-    environmentName: environmentName
-    environmentPrefix: environmentPrefix
-    stackNameSuffix: stackNameSuffix
+    vnet1Name: containerAppEnvironment.outputs.virtualNetworkName
+    vnet2Name: egressFirewall.outputs.firewallVnetName
+    vnet1ToVnet2PeeringName: 'peering-fw-shared-01'
+    vnet2ToVnet1PeeringName: 'peering-cae-01'
   }
 }
 

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -114,6 +114,7 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     environmentPrefix: environmentPrefix
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
+    containerRegistryDataEndpointHostNames: containerRegistry.outputs.dataEndpointHostNames
     keyVaultName: secrets.outputs.name
     allowedNhsFqdns: allowedNhsFqdns
     logAnalyticsWorkspaceId: observability.outputs.workspaceId

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -109,7 +109,6 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     keyVaultName: secrets.outputs.name
-    keyVaultEndpoint: '${secrets.outputs.name}.vault.azure.net'
     caeVnetAddressPrefixes: [
       containerAppVnet
     ]
@@ -163,13 +162,8 @@ module clientInfrastructure '../../modules/client-agent/infrastructure.bicep' = 
     network: clientNetwork
     subnetRange: clientSubnetRange
     location: location
-    containerAppEnvironmentVnetName: containerAppEnvironment.outputs.virtualNetworkName
-    containerAppEnvironmentResourceGroupName: resourceGroup().name
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
     logAnalyticsWorkspaceResourceGroupName: resourceGroup().name
-    containerRegistryEndpoint: containerRegistry.outputs.endpoint
-    keyVaultName: secrets.outputs.name
-    keyVaultEndpoint: '${secrets.outputs.name}.vault.azure.net'
     tags: tags
   }
 }
@@ -191,5 +185,5 @@ output SECRETS_VAULTURI string = secrets.outputs.vaultUri
 output SECRETS_VAULT_NAME string = secrets.outputs.name
 output CLIENT_VM_NAME string = clientInfrastructure.outputs.vmName
 output CLIENT_VIRTUAL_NETWORK_NAME string = clientInfrastructure.outputs.clientVirtualNetworkName
-output CLIENT_FIREWALL_NAME string = clientInfrastructure.outputs.firewallName
-output CLIENT_ROUTE_TABLE_NAME string = clientInfrastructure.outputs.routeTableName
+output CLIENT_FIREWALL_NAME string = egressFirewall.outputs.firewallName
+output CLIENT_ROUTE_TABLE_NAME string = egressFirewall.outputs.routeTableName

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -125,6 +125,29 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
   }
 }
 
+module containerAppNetwork '../../modules/shared/container-app-network.bicep' = {
+  name: 'container-app-network'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    stackNameSuffix: stackNameSuffix
+    containerAppVnet: containerAppVnet
+    tags: tags
+  }
+}
+
+module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
+  name: 'cae-firewall-peering'
+  params: {
+    vnet1Name: containerAppNetwork.outputs.virtualNetworkName
+    vnet2Name: egressFirewall.outputs.firewallVnetName
+    vnet1ToVnet2PeeringName: 'peering-fw-shared-01'
+    vnet2ToVnet1PeeringName: 'peering-cae-01'
+    vnet1AllowForwardedTraffic: true
+  }
+}
+
 module containerAppEnvironment '../../modules/shared/container-app-environment.bicep' = {
   name: 'container-app-environment'
   params: {
@@ -133,23 +156,15 @@ module containerAppEnvironment '../../modules/shared/container-app-environment.b
     lowercaseEnvironmentName: lowercaseEnvironmentName
     stackNameSuffix: stackNameSuffix
     containerAppManagedEnvironmentNumber: containerAppManagedEnvironmentNumber
-    containerAppVnet: containerAppVnet
+    virtualNetworkName: containerAppNetwork.outputs.virtualNetworkName
     containerAppEnvSubnet: containerAppEnvSubnet
     tags: tags
     logAnalyticsWorkspaceName: observability.outputs.workspaceName
     routeTableId: egressFirewall.outputs.routeTableId
   }
-}
-
-module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' = {
-  name: 'cae-firewall-peering'
-  params: {
-    vnet1Name: containerAppEnvironment.outputs.virtualNetworkName
-    vnet2Name: egressFirewall.outputs.firewallVnetName
-    vnet1ToVnet2PeeringName: 'peering-fw-shared-01'
-    vnet2ToVnet1PeeringName: 'peering-cae-01'
-    vnet1AllowForwardedTraffic: true
-  }
+  dependsOn: [
+    caeFirewallPeering
+  ]
 }
 
 module monitoring '../../modules/shared/monitoring.bicep' = {

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -144,7 +144,7 @@ module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' =
   params: {
     vnet1Name: containerAppNetwork.outputs.virtualNetworkName
     vnet2Name: egressFirewall.outputs.firewallVnetName
-    vnet1ToVnet2PeeringName: 'peering-fw-shared-01'
+    vnet1ToVnet2PeeringName: 'peering-fw-01'
     vnet2ToVnet1PeeringName: 'peering-cae-01'
     vnet1AllowForwardedTraffic: true
   }

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -49,11 +49,13 @@ param clientSubnetRange string = '192.168.0.128/26'
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'ca'
 var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
-var allowedNhsFqdns = isProductionEnvironment ? [
-  'api.service.nhs.uk'
-] : [
-  'int.api.service.nhs.uk'
-]
+var allowedNhsFqdns = isProductionEnvironment
+  ? [
+      'api.service.nhs.uk'
+    ]
+  : [
+      'int.api.service.nhs.uk'
+    ]
 var tags = {
   'azd-env-name': environmentName
   Product: 'SUI'


### PR DESCRIPTION
## Summary

Add a firewall, route table and peering so traffic in the CAE VNET can only pass out through it.

## Changes

- CAE now has a routeTableId paramter that is required
- Created the egress Firewall and policies as shared module.
- Created Peering as shared module
- Created a Public IP for the firewall (Unsure if this is possible just yet)
- 

## Validation

- run local bicep file checks
- run a what-if https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26813119847
