### PR TITLE
feat: 1796 - matching and external apis into cae

### DIFF
--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -11,6 +11,7 @@ Current scope:
 - blob containers for incoming, processed, and success files
 - primary and poison storage queues for the processing job contract
 - blob and queue private endpoints for the configured storage account
+- matching API and external API container apps (internal ingress) deployed into the stack's CAE
 
 `infra/stacks/blob-event-processor/subscription.bicep` is the subscription-scope entry point for this stack. By default, `resourceGroupMode=create` creates or updates the stack-owned `blob-event-processor` resource group and then deploys `main.bicep` into it.
 
@@ -75,6 +76,8 @@ az deployment sub what-if \
     containerAppPeSubnet=<private-endpoint-subnet-cidr> \
     includeRoleAssignments=true \
     storageProcessJobImageTag=<image-tag> \
+    matchingApiImageTag=<image-tag> \
+    externalApiImageTag=<image-tag> \
     turnOnAlerts=false \
     resourceGroupMode=existing \
     targetResourceGroupName=<existing-resource-group-name> \
@@ -88,8 +91,6 @@ If Azure CLI cannot write to the default local config directory, set `AZURE_CONF
 
 Follow up work:
 
-- ACA - Deploying to the ACR
-- Match/External/Yarp - Infrastructure and deployment to the ACR
 - Any further network/infrastructure needs for the processing job
 
 ## Unique to blob stack infrastructure

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -40,6 +40,14 @@ param turnOnAlerts bool = false
 @description('Container image tag for the storage process job')
 param storageProcessJobImageTag string = 'latest'
 
+@minLength(1)
+@description('Container image tag for the matching API')
+param matchingApiImageTag string = 'latest'
+
+@minLength(1)
+@description('Container image tag for the external API')
+param externalApiImageTag string = 'latest'
+
 @description('Whether or not to include role assignments, since some environments may restrict these.')
 param includeRoleAssignments bool = true
 
@@ -213,6 +221,43 @@ module storageProcessJob '../../modules/blob-event-processor/container-app-job.b
   ]
 }
 
+module matchingApi '../../modules/api-apps/matching-api.bicep' = {
+  name: 'matching-api'
+  params: {
+    location: location
+    containerAppsEnvironmentId: containerAppEnvironment.outputs.id
+    containerAppsEnvironmentDefaultDomain: containerAppEnvironment.outputs.defaultDomain
+    containerRegistryServer: containerRegistry.outputs.endpoint
+    containerRegistryName: containerRegistry.outputs.name
+    managedIdentityId: identity.outputs.id
+    managedIdentityPrincipalId: identity.outputs.principalId
+    managedIdentityClientId: identity.outputs.clientId
+    environmentName: environmentName
+    imageTag: matchingApiImageTag
+    applicationInsightsConnectionString: observability.outputs.applicationInsightsConnectionString
+    tags: tags
+  }
+}
+
+module externalApi '../../modules/api-apps/external-api.bicep' = {
+  name: 'external-api'
+  params: {
+    location: location
+    containerAppsEnvironmentId: containerAppEnvironment.outputs.id
+    containerRegistryServer: containerRegistry.outputs.endpoint
+    containerRegistryName: containerRegistry.outputs.name
+    managedIdentityId: identity.outputs.id
+    managedIdentityPrincipalId: identity.outputs.principalId
+    managedIdentityClientId: identity.outputs.clientId
+    environmentName: environmentName
+    imageTag: externalApiImageTag
+    keyVaultName: secrets.outputs.name
+    keyVaultUri: secrets.outputs.vaultUri
+    applicationInsightsConnectionString: observability.outputs.applicationInsightsConnectionString
+    tags: tags
+  }
+}
+
 output STACK_NAME string = 'blob-event-processor'
 output LOCATION string = location
 output TAGS object = tags
@@ -245,3 +290,7 @@ output EVENT_GRID_EVENT_SUBSCRIPTION_NAME string = eventGrid.outputs.eventSubscr
 output EVENT_GRID_EVENT_SUBSCRIPTION_ID string = eventGrid.outputs.eventSubscriptionId
 output STORAGE_PROCESS_JOB_NAME string = storageProcessJob.outputs.jobName
 output STORAGE_PROCESS_JOB_ID string = storageProcessJob.outputs.jobId
+output MATCHING_API_NAME string = matchingApi.outputs.name
+output MATCHING_API_ID string = matchingApi.outputs.id
+output EXTERNAL_API_NAME string = externalApi.outputs.name
+output EXTERNAL_API_ID string = externalApi.outputs.id

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -39,6 +39,14 @@ param turnOnAlerts bool = false
 @description('Container image tag for the storage process job')
 param storageProcessJobImageTag string = 'latest'
 
+@minLength(1)
+@description('Container image tag for the matching API')
+param matchingApiImageTag string = 'latest'
+
+@minLength(1)
+@description('Container image tag for the external API')
+param externalApiImageTag string = 'latest'
+
 @description('Whether or not to include role assignments, since some environments may restrict these.')
 param includeRoleAssignments bool = true
 
@@ -94,6 +102,8 @@ module stackDeployment 'main.bicep' = {
     monitoringActionGroupEmail: monitoringActionGroupEmail
     turnOnAlerts: turnOnAlerts
     storageProcessJobImageTag: storageProcessJobImageTag
+    matchingApiImageTag: matchingApiImageTag
+    externalApiImageTag: externalApiImageTag
     includeRoleAssignments: includeRoleAssignments
     storageAccountMode: storageAccountMode
     existingStorageAccountName: existingStorageAccountName
@@ -137,3 +147,7 @@ output EVENT_GRID_EVENT_SUBSCRIPTION_NAME string = stackDeployment.outputs.EVENT
 output EVENT_GRID_EVENT_SUBSCRIPTION_ID string = stackDeployment.outputs.EVENT_GRID_EVENT_SUBSCRIPTION_ID
 output STORAGE_PROCESS_JOB_NAME string = stackDeployment.outputs.STORAGE_PROCESS_JOB_NAME
 output STORAGE_PROCESS_JOB_ID string = stackDeployment.outputs.STORAGE_PROCESS_JOB_ID
+output MATCHING_API_NAME string = stackDeployment.outputs.MATCHING_API_NAME
+output MATCHING_API_ID string = stackDeployment.outputs.MATCHING_API_ID
+output EXTERNAL_API_NAME string = stackDeployment.outputs.EXTERNAL_API_NAME
+output EXTERNAL_API_ID string = stackDeployment.outputs.EXTERNAL_API_ID


### PR DESCRIPTION
## Summary

Update the infrastructure to create the ACAE apps for External and Matching

## Changes

- Update main and subscription for blob stack to include a 'latest' tag to use

## Validation

- az bicep build --file infra/stacks/blob-event-processor/subscription.bicep
-  az bicep build --file infra/stacks/blob-event-processor/main.bicep
- https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26807491036 - this looks to be right from reading the output. There is a lot of noise with other changes as well

## Notes

- This still aligns with the circular dependency of it needing an image firs. This will be fixed later
- Currently the APIs are in the registry from another workflow
