### PR TITLE
ci: - fix acrpull identity

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -68,6 +68,14 @@ inputs:
     description: "Optional storage process job image tag"
     required: false
     default: ""
+  matching_api_image_tag:
+    description: "Optional matching API image tag"
+    required: false
+    default: ""
+  external_api_image_tag:
+    description: "Optional external API image tag"
+    required: false
+    default: ""
   azure_include_role_assignments:
     description: Whether or not to include role assignments, since some environments may restrict these. 
     default: true
@@ -153,6 +161,14 @@ runs:
 
         if [ -n "${{ inputs.storage_process_job_image_tag }}" ]; then
           PARAMETERS+=("storageProcessJobImageTag=${{ inputs.storage_process_job_image_tag }}")
+        fi
+
+        if [ -n "${{ inputs.matching_api_image_tag }}" ]; then
+          PARAMETERS+=("matchingApiImageTag=${{ inputs.matching_api_image_tag }}")
+        fi
+
+        if [ -n "${{ inputs.external_api_image_tag }}" ]; then
+          PARAMETERS+=("externalApiImageTag=${{ inputs.external_api_image_tag }}")
         fi
 
         if [ -n "${{ inputs.resource_group_mode }}" ]; then

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -27,6 +27,16 @@ on:
         default: 'latest'
         required: false
         type: string
+      matching_api_image_tag:
+        description: Matching API image tag
+        default: 'latest'
+        required: false
+        type: string
+      external_api_image_tag:
+        description: External API image tag
+        default: 'latest'
+        required: false
+        type: string
       turn_on_alerts:
         description: Enable monitoring alerts
         default: false
@@ -78,6 +88,8 @@ env:
   AZURE_INCLUDE_ROLE_ASSIGNMENTS: ${{ inputs.include_role_assignments }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
+  MATCHING_API_IMAGE_TAG: ${{ inputs.matching_api_image_tag || 'latest' }}
+  EXTERNAL_API_IMAGE_TAG: ${{ inputs.external_api_image_tag || 'latest' }}
   RESOURCE_GROUP_MODE: ${{ inputs.resource_group_mode || 'create' }}
   TARGET_RESOURCE_GROUP_NAME: ${{ inputs.target_resource_group_name }}
   STORAGE_ACCOUNT_MODE: ${{ inputs.storage_account_mode || 'create' }}
@@ -192,6 +204,8 @@ jobs:
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
           storage_process_job_image_tag: ${{ env.STORAGE_PROCESS_JOB_IMAGE_TAG }}
+          matching_api_image_tag: ${{ env.MATCHING_API_IMAGE_TAG }}
+          external_api_image_tag: ${{ env.EXTERNAL_API_IMAGE_TAG }}
           resource_group_mode: ${{ env.RESOURCE_GROUP_MODE }}
           target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
           storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}
@@ -234,6 +248,8 @@ jobs:
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
           turn_on_alerts: ${{ env.AZURE_TURN_ON_ALERTS }}
           storage_process_job_image_tag: ${{ env.STORAGE_PROCESS_JOB_IMAGE_TAG }}
+          matching_api_image_tag: ${{ env.MATCHING_API_IMAGE_TAG }}
+          external_api_image_tag: ${{ env.EXTERNAL_API_IMAGE_TAG }}
           resource_group_mode: ${{ env.RESOURCE_GROUP_MODE }}
           target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
           storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}

--- a/infra/modules/api-apps/external-api.bicep
+++ b/infra/modules/api-apps/external-api.bicep
@@ -7,9 +7,6 @@ param containerAppsEnvironmentId string
 @description('The login server for the container registry')
 param containerRegistryServer string
 
-@description('The container registry resource name')
-param containerRegistryName string
-
 @description('The resource ID of the managed identity')
 param managedIdentityId string
 
@@ -41,14 +38,6 @@ param tags object = {}
 
 var appName = 'external-api'
 var targetPort = 8080
-
-module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
-  name: '${appName}-acr-pull-rbac'
-  params: {
-    containerRegistryName: containerRegistryName
-    principalId: managedIdentityPrincipalId
-  }
-}
 
 module keyVaultSecretsUserRbac '../shared/key-vault-secrets-user-rbac.bicep' = {
   name: '${appName}-kv-secrets-user-rbac'
@@ -151,7 +140,6 @@ resource externalApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
     }
   }
   dependsOn: [
-    acrPullRbac
     keyVaultSecretsUserRbac
   ]
 }

--- a/infra/modules/api-apps/matching-api.bicep
+++ b/infra/modules/api-apps/matching-api.bicep
@@ -10,14 +10,8 @@ param containerAppsEnvironmentDefaultDomain string
 @description('The login server for the container registry')
 param containerRegistryServer string
 
-@description('The container registry resource name')
-param containerRegistryName string
-
 @description('The resource ID of the managed identity')
 param managedIdentityId string
-
-@description('The principal ID of the managed identity, used for RBAC assignments')
-param managedIdentityPrincipalId string
 
 @description('The client ID of the managed identity')
 param managedIdentityClientId string
@@ -38,14 +32,6 @@ param tags object = {}
 var appName = 'matching-api'
 var externalApiName = 'external-api'
 var targetPort = 8080
-
-module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
-  name: '${appName}-acr-pull-rbac'
-  params: {
-    containerRegistryName: containerRegistryName
-    principalId: managedIdentityPrincipalId
-  }
-}
 
 resource matchingApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
   name: appName
@@ -139,9 +125,6 @@ resource matchingApi 'Microsoft.App/containerApps@2024-10-02-preview' = {
       }
     }
   }
-  dependsOn: [
-    acrPullRbac
-  ]
 }
 
 output name string = matchingApi.name

--- a/infra/modules/api-apps/yarp.bicep
+++ b/infra/modules/api-apps/yarp.bicep
@@ -10,14 +10,8 @@ param containerAppsEnvironmentDefaultDomain string
 @description('The login server for the container registry')
 param containerRegistryServer string
 
-@description('The container registry resource name')
-param containerRegistryName string
-
 @description('The resource ID of the managed identity')
 param managedIdentityId string
-
-@description('The principal ID of the managed identity, used for RBAC assignments')
-param managedIdentityPrincipalId string
 
 @description('The client ID of the managed identity')
 param managedIdentityClientId string
@@ -38,14 +32,6 @@ param tags object = {}
 var appName = 'yarp'
 var matchingApiName = 'matching-api'
 var targetPort = 8080
-
-module acrPullRbac '../shared/acr-pull-rbac.bicep' = {
-  name: '${appName}-acr-pull-rbac'
-  params: {
-    containerRegistryName: containerRegistryName
-    principalId: managedIdentityPrincipalId
-  }
-}
 
 resource yarp 'Microsoft.App/containerApps@2024-10-02-preview' = {
   name: appName
@@ -139,9 +125,6 @@ resource yarp 'Microsoft.App/containerApps@2024-10-02-preview' = {
       }
     }
   }
-  dependsOn: [
-    acrPullRbac
-  ]
 }
 
 output name string = yarp.name

--- a/infra/modules/shared/identity.bicep
+++ b/infra/modules/shared/identity.bicep
@@ -10,6 +10,12 @@ param lowercaseEnvironmentName string
 @description('Short stack-specific suffix used to avoid cross-stack name collisions.')
 param stackNameSuffix string = ''
 
+@description('Whether or not to include role assignments, since some environments may restrict these.')
+param includeRoleAssignments bool = true
+
+@description('The container registry resource name to grant this identity AcrPull on. Leave empty to skip the grant.')
+param containerRegistryName string = ''
+
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
@@ -19,6 +25,15 @@ resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-
   name: '${environmentPrefix}-${lowercaseEnvironmentName}${stackNameToken}-mi-01'
   location: location
   tags: tags
+}
+
+// empty name check for backwards compatibility with legacy deploy
+module acrPullRbac '../shared/acr-pull-rbac.bicep' = if (includeRoleAssignments && !empty(containerRegistryName)) {
+  name: 'identity-acr-pull-rbac'
+  params: {
+    containerRegistryName: containerRegistryName
+    principalId: managedIdentity.properties.principalId
+  }
 }
 
 output clientId string = managedIdentity.properties.clientId

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -80,6 +80,8 @@ module identity '../../modules/shared/identity.bicep' = {
     environmentPrefix: environmentPrefix
     lowercaseEnvironmentName: lowercaseEnvironmentName
     stackNameSuffix: stackNameSuffix
+    includeRoleAssignments: includeRoleAssignments
+    containerRegistryName: containerRegistry.outputs.name
     tags: tags
   }
 }
@@ -92,14 +94,6 @@ module containerRegistry '../../modules/shared/container-registry.bicep' = {
     lowercaseEnvironmentName: lowercaseEnvironmentName
     stackNameSuffix: stackNameSuffix
     tags: tags
-  }
-}
-
-module storageProcessJobAcrPullRbac '../../modules/shared/acr-pull-rbac.bicep' = if (includeRoleAssignments) {
-  name: 'storage-process-job-acr-pull-rbac'
-  params: {
-    containerRegistryName: containerRegistry.outputs.name
-    principalId: identity.outputs.principalId
   }
 }
 
@@ -216,9 +210,6 @@ module storageProcessJob '../../modules/blob-event-processor/container-app-job.b
     tags: tags
     includeRoleAssignments: includeRoleAssignments
   }
-  dependsOn: [
-    storageProcessJobAcrPullRbac
-  ]
 }
 
 module matchingApi '../../modules/api-apps/matching-api.bicep' = {
@@ -228,9 +219,7 @@ module matchingApi '../../modules/api-apps/matching-api.bicep' = {
     containerAppsEnvironmentId: containerAppEnvironment.outputs.id
     containerAppsEnvironmentDefaultDomain: containerAppEnvironment.outputs.defaultDomain
     containerRegistryServer: containerRegistry.outputs.endpoint
-    containerRegistryName: containerRegistry.outputs.name
     managedIdentityId: identity.outputs.id
-    managedIdentityPrincipalId: identity.outputs.principalId
     managedIdentityClientId: identity.outputs.clientId
     environmentName: environmentName
     imageTag: matchingApiImageTag
@@ -245,7 +234,6 @@ module externalApi '../../modules/api-apps/external-api.bicep' = {
     location: location
     containerAppsEnvironmentId: containerAppEnvironment.outputs.id
     containerRegistryServer: containerRegistry.outputs.endpoint
-    containerRegistryName: containerRegistry.outputs.name
     managedIdentityId: identity.outputs.id
     managedIdentityPrincipalId: identity.outputs.principalId
     managedIdentityClientId: identity.outputs.clientId


### PR DESCRIPTION

## Summary

ACR pull was being granted in four places, all producing the same role assignment against the shared identity. It's now granted once, inside the shared identity module, with a flag to tell it to try and assign or not.

## Changes

- identity module now receives includeRoleAssignments + containerRegistryName: containerRegistry.outputs.name
- Deleted the standalone storageProcessJobAcrPullRbac module - not necessary now
- matching-api.bicep, external-api.bicep, yarp.bicep, removed the acrPullRbac module block
- Out of scope but added: add ability to add tag for matching and external from workflow

## Validation

- ran az build files locally for error validation
- what-if with role assign - https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26816973703
- what-if no role assign - https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26817061114

<!--
Optional: add extra context below when relevant, for example:
- deferred findings or follow-up work
- rollout notes
- known limitations
- reviewer-specific context
-->
