### PR TITLE
feat: make matching client api route url flexible

### DIFF
--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
@@ -9,6 +9,8 @@ namespace SUI.Client.Core.Infrastructure.Http;
 
 public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClient
 {
+    private const string MatchPersonPath = "api/v1/matchperson";
+
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
         Converters = { new JsonStringEnumConverter() },
@@ -21,7 +23,7 @@ public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClien
     )
     {
         var response = await httpClient.PostAsJsonAsync(
-            "/api/v1/matchperson",
+            BuildRequestUri(MatchPersonPath),
             payload,
             cancellationToken
         );
@@ -61,5 +63,21 @@ public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClien
         }
 
         return null;
+    }
+
+    private Uri BuildRequestUri(string relativePath)
+    {
+        if (httpClient.BaseAddress is null)
+        {
+            return new Uri(relativePath, UriKind.Relative);
+        }
+
+        var baseAddress = httpClient.BaseAddress.ToString();
+        if (!baseAddress.EndsWith('/'))
+        {
+            baseAddress += "/";
+        }
+
+        return new Uri(new Uri(baseAddress), relativePath);
     }
 }

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
@@ -21,7 +21,7 @@ public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClien
     )
     {
         var response = await httpClient.PostAsJsonAsync(
-            "/matching/api/v1/matchperson",
+            "/api/v1/matchperson",
             payload,
             cancellationToken
         );

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
@@ -72,8 +72,7 @@ public class MatchingApiClientTests
                 ItExpr.Is<HttpRequestMessage>(req =>
                     req.Method == HttpMethod.Post
                     && req.RequestUri != null
-                    && req.RequestUri.ToString()
-                        == "http://localhost:5000/matching/api/v1/matchperson"
+                    && req.RequestUri.ToString() == "http://localhost:5000/api/v1/matchperson"
                 ),
                 ItExpr.IsAny<CancellationToken>()
             );

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
@@ -6,7 +6,7 @@ using Shared;
 using Shared.Models;
 using SUI.Client.Core.Infrastructure.Http;
 
-namespace Unit.Tests.StorageProcessFunction;
+namespace Unit.Tests.Client.CoreTests.InfrastructureTests;
 
 public class MatchingApiClientTests
 {
@@ -76,6 +76,54 @@ public class MatchingApiClientTests
                 ),
                 ItExpr.IsAny<CancellationToken>()
             );
+    }
+
+    [Theory]
+    [InlineData("http://localhost:5000", "http://localhost:5000/api/v1/matchperson")]
+    [InlineData("http://localhost:5000/", "http://localhost:5000/api/v1/matchperson")]
+    [InlineData(
+        "http://localhost:5000/matching",
+        "http://localhost:5000/matching/api/v1/matchperson"
+    )]
+    [InlineData(
+        "http://localhost:5000/matching/",
+        "http://localhost:5000/matching/api/v1/matchperson"
+    )]
+    public async Task Should_PreserveRouteRoot_When_BaseAddressTrailingSlashVaries(
+        string baseAddress,
+        string expectedRequestUri
+    )
+    {
+        Uri? requestUri = null;
+        var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Returns<HttpRequestMessage, CancellationToken>(
+                (request, _) =>
+                {
+                    requestUri = request.RequestUri;
+                    return Task.FromResult(
+                        new HttpResponseMessage
+                        {
+                            StatusCode = HttpStatusCode.OK,
+                            Content = JsonContent.Create(new PersonMatchResponse()),
+                        }
+                    );
+                }
+            );
+
+        var httpClient = new HttpClient(handlerMock.Object) { BaseAddress = new Uri(baseAddress) };
+        var sut = new MatchingApiClient(httpClient);
+
+        await sut.MatchPersonAsync(new SearchSpecification(), CancellationToken.None);
+
+        // A leading slash in the client path would drop the configured /matching route root.
+        Assert.Equal(expectedRequestUri, requestUri?.ToString());
     }
 
     [Fact]


### PR DESCRIPTION

## Summary

The routing was still setup to assume Yarp was involved where yarp used the route root 'matching'.
This PR addresses that by using a relative url instead and the client can set the base address, making it more flexible too.

## Changes

- Matching API client now has a address builder and ensures that if any slashes are missing, it still works. Not entirely necessary but avoids any issues.
-
-

## Validation

- This has been deployed to Azure and verified it's working
- Unit tests also show it correctly uses base url and can fix / issues
