### PR TITLE
ci: include the role assignment flag for keyvault rbac

### DIFF
--- a/infra/modules/api-apps/external-api.bicep
+++ b/infra/modules/api-apps/external-api.bicep
@@ -36,10 +36,13 @@ param applicationInsightsConnectionString string
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
+@description('Whether or not to include role assignments')
+param includeRoleAssignments bool = true
+
 var appName = 'external-api'
 var targetPort = 8080
 
-module keyVaultSecretsUserRbac '../shared/key-vault-secrets-user-rbac.bicep' = {
+module keyVaultSecretsUserRbac '../shared/key-vault-secrets-user-rbac.bicep' = if (includeRoleAssignments) {
   name: '${appName}-kv-secrets-user-rbac'
   params: {
     keyVaultName: keyVaultName

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -243,6 +243,7 @@ module externalApi '../../modules/api-apps/external-api.bicep' = {
     keyVaultUri: secrets.outputs.vaultUri
     applicationInsightsConnectionString: observability.outputs.applicationInsightsConnectionString
     tags: tags
+    includeRoleAssignments: includeRoleAssignments
   }
 }
 


### PR DESCRIPTION
<!--
Ensure PR title follows the conventional commit format with a ticket reference:
<type>: SUI-1234 - concise description
-->

## Summary

include the role assignment flag for keyvault rbac. Without this change, if the role still exists, then it will fail by trying to assign it again.

## Changes

- Added the existing bool flag for assignment to the keyvault RBAC role assignment as well

## Validation

- https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26843212076 - successful run with this change
