### PR TITLE
feat: add a private link and dns to keyvault and update outputs

### DIFF
--- a/infra/modules/shared/key-vault-private-endpoint.bicep
+++ b/infra/modules/shared/key-vault-private-endpoint.bicep
@@ -1,0 +1,75 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('The name of the Key Vault to expose via a private endpoint')
+param keyVaultName string
+
+@description('The resource ID of the subnet for the private endpoint')
+param peSubnetId string
+
+@description('The resource ID of the virtual network for the private DNS zone link')
+param vnetId string
+
+resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+  name: keyVaultName
+}
+
+resource keyVaultPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
+  name: '${keyVaultName}-kv-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: peSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${keyVaultName}-kv-pe-conn'
+        properties: {
+          privateLinkServiceId: keyVault.id
+          groupIds: [
+            'vault'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// https://learn.microsoft.com/en-us/azure/key-vault/general/private-link-service?tabs=portal - explains the name
+resource keyVaultDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
+  name: 'privatelink.vaultcore.azure.net'
+  location: 'global'
+  tags: tags
+}
+
+resource keyVaultDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
+  parent: keyVaultDnsZone
+  name: '${keyVaultName}-kv-dns-link'
+  location: 'global'
+  tags: tags
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: {
+      id: vnetId
+    }
+  }
+}
+
+resource keyVaultDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
+  parent: keyVaultPrivateEndpoint
+  name: 'default'
+  properties: {
+    privateDnsZoneConfigs: [
+      {
+        name: replace(keyVaultDnsZone.name, '.', '-')
+        properties: {
+          privateDnsZoneId: keyVaultDnsZone.id
+        }
+      }
+    ]
+  }
+}

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -134,6 +134,17 @@ module secrets '../../modules/shared/secrets.bicep' = {
   }
 }
 
+module keyVaultPrivateEndpoint '../../modules/shared/key-vault-private-endpoint.bicep' = {
+  name: 'secrets-private-endpoint'
+  params: {
+    location: location
+    tags: tags
+    keyVaultName: secrets.outputs.name
+    peSubnetId: containerAppEnvironment.outputs.privateEndpointSubnetId
+    vnetId: containerAppEnvironment.outputs.virtualNetworkId
+  }
+}
+
 module monitoring '../../modules/shared/monitoring.bicep' = {
   name: 'monitoring'
   params: {


### PR DESCRIPTION
<!--
Ensure PR title follows the conventional commit format with a ticket reference:
<type>: SUI-1234 - concise description
-->

## Summary

Currently the public access is turned off on the CAE so outbound connections cannot work with keyvault through the public internet. This PR is to create that private link so it can connect.

## Changes

- Added private link and DNS zone and linked the to the CAE VNET and Keyvault

## Validation

- https://github.com/DFE-Digital/SUI_Matcher/actions/runs/26876207101 - this shows the resources will be created.
- run build file locally

## Note:

https://learn.microsoft.com/en-us/azure/key-vault/general/private-link-service?tabs=portal troubleshooting guide shows that we need to use the privatelink.vaultcore.azure.net dns zone name. The caveat as far as I can tell is as long as we don't need another keyvault in the same RG then this should be ok.
