### PR TITLE
forward traffic on both peers

### DIFF
--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -108,6 +108,21 @@ var platformFqdnRules = [
     #disable-next-line no-hardcoded-env-urls
     fqdn: '*.identity.azure.net'
   }
+  {
+    name: 'monitor-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'northeurope.livediagnostics.monitor.azure.com'
+  }
+  {
+    name: 'app-insights-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'northeurope-2.in.applicationinsights.azure.com'
+  }
+  {
+    name: 'visualstudio-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'dc.services.visualstudio.com'
+  }
 ]
 
 var containerRegistryDataEndpointFqdnRules = [

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -16,6 +16,9 @@ param containerRegistryEndpoint string
 @description('The dedicated data endpoint host names for the Premium container registry to allow through the firewall')
 param containerRegistryDataEndpointHostNames array
 
+@description('The Application Insights ingestion host allowed through the firewall')
+param applicationInsightsIngestionHost string
+
 @description('The name of the shared Key Vault')
 param keyVaultName string
 
@@ -115,8 +118,7 @@ var platformFqdnRules = [
   }
   {
     name: 'app-insights-allow'
-    #disable-next-line no-hardcoded-env-urls
-    fqdn: '${containerAppRegion}-2.in.applicationinsights.azure.com'
+    fqdn: applicationInsightsIngestionHost
   }
   {
     name: 'visualstudio-allow'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -111,12 +111,12 @@ var platformFqdnRules = [
   {
     name: 'monitor-allow'
     #disable-next-line no-hardcoded-env-urls
-    fqdn: 'northeurope.livediagnostics.monitor.azure.com'
+    fqdn: '${containerAppRegion}.livediagnostics.monitor.azure.com'
   }
   {
     name: 'app-insights-allow'
     #disable-next-line no-hardcoded-env-urls
-    fqdn: 'northeurope-2.in.applicationinsights.azure.com'
+    fqdn: '${containerAppRegion}-2.in.applicationinsights.azure.com'
   }
   {
     name: 'visualstudio-allow'

--- a/infra/modules/shared/observability.bicep
+++ b/infra/modules/shared/observability.bicep
@@ -61,6 +61,10 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   }
 }
 
+var applicationInsightsIngestionEndpoint = split(split(applicationInsights.properties.ConnectionString, 'IngestionEndpoint=')[1], ';')[0]
+var applicationInsightsIngestionHost = split(replace(replace(applicationInsightsIngestionEndpoint, 'https://', ''), 'http://', ''), '/')[0]
+
 output workspaceName string = logAnalyticsWorkspace.name
 output workspaceId string = logAnalyticsWorkspace.id
 output applicationInsightsConnectionString string = applicationInsights.properties.ConnectionString
+output applicationInsightsIngestionHost string = applicationInsightsIngestionHost

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -123,6 +123,7 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     containerRegistryDataEndpointHostNames: containerRegistry.outputs.dataEndpointHostNames
+    applicationInsightsIngestionHost: observability.outputs.applicationInsightsIngestionHost
     keyVaultName: secrets.outputs.name
     allowKeyVaultPublicEgress: false
     allowedNhsFqdns: allowedNhsFqdns

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -155,6 +155,7 @@ module caeFirewallPeering '../../modules/shared/virtual-network-peering.bicep' =
     vnet1ToVnet2PeeringName: 'peering-fw-01'
     vnet2ToVnet1PeeringName: 'peering-cae-01'
     vnet1AllowForwardedTraffic: true
+    vnet2AllowForwardedTraffic: true
   }
 }
 

--- a/infra/stacks/client-agent/main.bicep
+++ b/infra/stacks/client-agent/main.bicep
@@ -117,6 +117,7 @@ module egressFirewall '../../modules/shared/egress-firewall.bicep' = {
     stackNameSuffix: stackNameSuffix
     containerRegistryEndpoint: containerRegistry.outputs.endpoint
     containerRegistryDataEndpointHostNames: containerRegistry.outputs.dataEndpointHostNames
+    applicationInsightsIngestionHost: observability.outputs.applicationInsightsIngestionHost
     keyVaultName: secrets.outputs.name
     allowedNhsFqdns: allowedNhsFqdns
     logAnalyticsWorkspaceId: observability.outputs.workspaceId


### PR DESCRIPTION
## Summary

In order for our Hub and Spoke style VNET peering to work, we must enable all forward peering traffic. At the moment the Firewall VNET is not forwarding traffic from the CAE VNET. https://learn.microsoft.com/en-us/azure/architecture/networking/architecture/hub-spoke - Communication through an NVA

## Changes

- Enable VNET2 to accept forwarded traffic
- Also added specific monitor log paths to allow app insights and monitor logs.

## Validation

- Successful what-if - https://github.com/DFE-Digital/SUI_Matcher/actions/runs/27152565420 shows peering becoming true.
- Successful file building for bicep files
- Tested that all outbound is blocked except for the ones in the firewall exceptions
