### PR TITLE
feat: 1809 - additional props are sent from client and logged in backend

### DIFF
--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvPersonSpecParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvPersonSpecParser.cs
@@ -35,6 +35,33 @@ public class CsvPersonSpecParser(IOptions<CsvMatchDataOptions> csvMatchDataOptio
             ]),
             Phone = record.GetFirstValueOrDefault([csvMatchDataOptions.Value.ColumnMappings.Phone]),
             RawBirthDate = [dob],
+            OptionalProperties = OptionalProperties(csvRecord),
         };
+    }
+
+    /// <summary>
+    /// Find and extract any properties from the CSV record that are not part of the standard mapped fields.
+    /// </summary>
+    /// <returns>Non-standard columns and values</returns>
+    private Dictionary<string, object> OptionalProperties(CsvRecordDto csvRecord)
+    {
+        var optionalColumns = csvRecord.Record.Where(kvp => !IsMappedColumn(kvp.Key));
+
+        var optionalProperties = optionalColumns
+            .Select(kvp => new KeyValuePair<string, object>(kvp.Key, kvp.Value))
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+        return optionalProperties;
+    }
+
+    private bool IsMappedColumn(string columnName)
+    {
+        var mappedColumns = csvMatchDataOptions
+            .Value.ColumnMappings.GetType()
+            .GetProperties()
+            .Select(p => p.GetValue(csvMatchDataOptions.Value.ColumnMappings)?.ToString())
+            .Where(v => v is not null)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        return mappedColumns.Contains(columnName);
     }
 }

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/MatchPeopleTests/MatchPersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/MatchPeopleTests/MatchPersonRecordOrchestratorTests.cs
@@ -34,7 +34,9 @@ public class MatchPersonRecordOrchestratorTests
                     Result = new MatchResult { MatchStatus = MatchStatus.Match },
                 }
             );
-        _personSpecParser.Setup(x => x.Parse(It.IsAny<PersonSpecification>())).Returns<PersonSpecification>(x => x);
+        _personSpecParser
+            .Setup(x => x.Parse(It.IsAny<PersonSpecification>()))
+            .Returns<PersonSpecification>(x => x);
         var sut = CreateSut();
 
         var result = await sut.ProcessAsync(content, "test-file.csv", CancellationToken.None);
@@ -46,6 +48,8 @@ public class MatchPersonRecordOrchestratorTests
         Assert.NotNull(sentPayload);
         Assert.Equal("Jane", sentPayload!.Given);
         Assert.Equal("Doe", sentPayload.Family);
+        Assert.Equal("CustomValue1", sentPayload.OptionalProperties["CustomField1"]);
+        Assert.Equal("123", sentPayload.OptionalProperties["CustomField2"]);
         Assert.Equal(new DateOnly(2012, 5, 10), sentPayload.BirthDate);
         var processedRecord = Assert.Single(result);
         Assert.Same(content[0], processedRecord.OriginalData);
@@ -71,9 +75,12 @@ public class MatchPersonRecordOrchestratorTests
                     Result = new MatchResult { MatchStatus = MatchStatus.Match },
                 }
             );
-        _personSpecParser.Setup(x => x.Parse(It.IsAny<PersonSpecification>())).Returns<PersonSpecification>(x => x);
+        _personSpecParser
+            .Setup(x => x.Parse(It.IsAny<PersonSpecification>()))
+            .Returns<PersonSpecification>(x => x);
 
-        var result = await CreateSut().ProcessAsync(content, "test-file.csv", CancellationToken.None);
+        var result = await CreateSut()
+            .ProcessAsync(content, "test-file.csv", CancellationToken.None);
 
         Assert.NotNull(sentPayload);
         Assert.Equal(
@@ -103,7 +110,9 @@ public class MatchPersonRecordOrchestratorTests
                     Result = new MatchResult { MatchStatus = MatchStatus.Match },
                 }
             );
-        _personSpecParser.Setup(x => x.Parse(It.IsAny<PersonSpecification>())).Returns<PersonSpecification>(x => x);
+        _personSpecParser
+            .Setup(x => x.Parse(It.IsAny<PersonSpecification>()))
+            .Returns<PersonSpecification>(x => x);
         var sut = CreateSut();
 
         var result = await sut.ProcessAsync(content, "test-file.csv", CancellationToken.None);
@@ -148,5 +157,10 @@ public class MatchPersonRecordOrchestratorTests
             BirthDate = birthDate,
             RawBirthDate = [birthDate.ToString("yyyy-MM-dd")],
             AddressPostalCode = postcode,
+            OptionalProperties = new Dictionary<string, object>
+            {
+                { "CustomField1", "CustomValue1" },
+                { "CustomField2", "123" },
+            },
         };
 }

--- a/tests/Unit.Tests/Client/ParserTests/CsvPersonSpecParserTests.cs
+++ b/tests/Unit.Tests/Client/ParserTests/CsvPersonSpecParserTests.cs
@@ -121,4 +121,26 @@ public class CsvPersonSpecParserTests
         Assert.NotNull(result.RawBirthDate);
         Assert.Equal(["not-a-date"], result.RawBirthDate);
     }
+
+    [Fact]
+    public void Should_ParseOptionalProperties_When_AdditionalColumnsArePresent()
+    {
+        var options = CreateDefaultOptions();
+        var sut = new CsvPersonSpecParser(options);
+        var record = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["GivenName"] = "Jane",
+            ["FamilyName"] = "Doe",
+            ["DOB"] = "2012-05-10",
+            ["Postcode"] = "SW1A 1AA",
+            ["CustomField1"] = "CustomValue1",
+            ["CustomField2"] = "CustomValue2",
+        };
+        var csvRecord = new CsvRecordDto(record);
+
+        var result = sut.Parse(csvRecord);
+
+        Assert.Equal("CustomValue1", result.OptionalProperties["CustomField1"]);
+        Assert.Equal("CustomValue2", result.OptionalProperties["CustomField2"]);
+    }
 }

--- a/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/BlobFileOrchestratorTests.cs
@@ -20,6 +20,10 @@ public class BlobFileOrchestratorTests
         Id,GivenName,FamilyName,DOB,Postcode
         1111,Jane,Doe,2012-05-10,SW1A 1AA
         """;
+    private const string ValidBlobContentExtraFields = """
+        Id,GivenName,FamilyName,DOB,Postcode,ExtraField1,ExtraField2
+        1111,Jane,Doe,2012-05-10,SW1A 1AA,ExtraValue1,ExtraValue2
+        """;
     private const string ValidBlobContentWithOptionalHeaders = """
         Id,GivenName,FamilyName,DOB,Postcode,Email,Gender,Phone
         1111,Jane,Doe,2012-05-10,SW1A 1AA,jane@example.com,F,07123456789
@@ -114,6 +118,42 @@ public class BlobFileOrchestratorTests
                 ),
             Times.Once
         );
+    }
+
+    [Fact]
+    public async Task Should_ProcessAdditionalColumns_When_AdditionalColumnsExist()
+    {
+        var queueMessage = new StorageBlobMessage("incoming", "test-file.csv");
+        IEnumerable<CsvRecordDto>? capturedRecords = null;
+
+        _blobFileReader
+            .Setup(x => x.GetBlobContents(queueMessage, CancellationToken.None))
+            .ReturnsAsync(BinaryData.FromString(ValidBlobContentExtraFields));
+        _blobPayloadProcessor
+            .Setup(x =>
+                x.ProcessAsync(
+                    It.IsAny<IEnumerable<CsvRecordDto>>(),
+                    "test-file.csv",
+                    CancellationToken.None
+                )
+            )
+            .Callback<IEnumerable<CsvRecordDto>, string, CancellationToken>(
+                (records, _, _) => capturedRecords = records.ToList()
+            )
+            .ReturnsAsync(CreateMatchedResults());
+
+        await _sut.ProcessAsync(queueMessage, CancellationToken.None);
+
+        _blobFileReader.Verify(
+            x => x.GetBlobContents(queueMessage, CancellationToken.None),
+            Times.Once
+        );
+
+        Assert.NotNull(capturedRecords);
+        var recordsList = capturedRecords.ToList();
+        var record = Assert.Single(recordsList);
+        Assert.Equal("ExtraValue1", record.Record["ExtraField1"]);
+        Assert.Equal("ExtraValue2", record.Record["ExtraField2"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Currently no additional properties are sent and logged in the backend. This ensures it is.

## Changes

- Added a method to find and get values of the non standard columns
- Some formatting updates as part of the pre-commit

## Validation

- Unit tested on - logical method, blob verify and match call verify

