### PR TITLE
feat: azure management url firewall

### DIFF
--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -75,7 +75,7 @@ var platformFqdnRules = [
   {
     name: 'mng-data-allow'
     #disable-next-line no-hardcoded-env-urls
-    fqdn: 'management.azure.com:443'
+    fqdn: 'management.azure.com'
   }
   {
     name: 'aks-packages-allow'

--- a/infra/modules/shared/egress-firewall.bicep
+++ b/infra/modules/shared/egress-firewall.bicep
@@ -73,6 +73,11 @@ var platformFqdnRules = [
     fqdn: '*.data.mcr.microsoft.com'
   }
   {
+    name: 'mng-data-allow'
+    #disable-next-line no-hardcoded-env-urls
+    fqdn: 'management.azure.com:443'
+  }
+  {
     name: 'aks-packages-allow'
     #disable-next-line no-hardcoded-env-urls
     fqdn: 'packages.aks.azure.com'


### PR DESCRIPTION
## Summary

Allows mandatory outbound traffic from the Container Apps Environment (CAE) subnet to the Azure Resource Manager (ARM) control plane over HTTPS.  Discovered in firewall deny logs.

## Changes

- Added the management.azure.com to firewall exceptions

## Validation

- az bicep build --file ./infra/modules/shared/egress-firewall.bicep


