### PR TITLE
fix: SUI-1973 - support existing storage resources

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: "Optional container app private endpoint subnet"
     required: false
     default: ""
+  tag_environment_name:
+    description: "Optional Environment tag value override"
+    required: false
+    default: ""
   stack_resource_group:
     description: "Target stack resource group"
     required: true
@@ -145,6 +149,10 @@ runs:
 
         if [ -n "${{ inputs.azure_container_app_pe_subnet }}" ]; then
           PARAMETERS+=("containerAppPeSubnet=${{ inputs.azure_container_app_pe_subnet }}")
+        fi
+
+        if [ -n "${{ inputs.tag_environment_name }}" ]; then
+          PARAMETERS+=("tagEnvironmentName=${{ inputs.tag_environment_name }}")
         fi
 
         if [ -n "${{ inputs.turn_on_alerts }}" ]; then

--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: "Optional Environment tag value override"
     required: false
     default: ""
+  additional_tags:
+    description: "Optional JSON object containing additional deployment tags"
+    required: false
+    default: ""
   stack_resource_group:
     description: "Target stack resource group"
     required: true
@@ -121,6 +125,8 @@ runs:
 
     - name: Run stack infrastructure command
       shell: bash
+      env:
+        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
       run: |
         set -euo pipefail
 
@@ -153,6 +159,11 @@ runs:
 
         if [ -n "${{ inputs.tag_environment_name }}" ]; then
           PARAMETERS+=("tagEnvironmentName=${{ inputs.tag_environment_name }}")
+        fi
+
+        if [ -n "${ADDITIONAL_TAGS}" ]; then
+          ADDITIONAL_TAGS_JSON="$(jq -nce --argjson tags "${ADDITIONAL_TAGS}" 'if ($tags | type) == "object" then $tags else error("additional_tags must be a JSON object") end')"
+          PARAMETERS+=("additionalTags=${ADDITIONAL_TAGS_JSON}")
         fi
 
         if [ -n "${{ inputs.turn_on_alerts }}" ]; then

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -85,6 +85,7 @@ env:
   AZURE_CONTAINER_APP_VNET: ${{ secrets.AZURE_CONTAINER_APP_VNET }}
   AZURE_CONTAINER_APP_ENV_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_ENV_SUBNET }}
   AZURE_CONTAINER_APP_PE_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_PE_SUBNET }}
+  AZURE_TAG_ENVIRONMENT_NAME: ${{ vars.AZURE_TAG_ENVIRONMENT_NAME }}
   AZURE_INCLUDE_ROLE_ASSIGNMENTS: ${{ inputs.include_role_assignments }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
@@ -199,6 +200,7 @@ jobs:
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
+          tag_environment_name: ${{ env.AZURE_TAG_ENVIRONMENT_NAME }}
           azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
@@ -243,6 +245,7 @@ jobs:
           azure_container_app_vnet: ${{ env.AZURE_CONTAINER_APP_VNET }}
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
+          tag_environment_name: ${{ env.AZURE_TAG_ENVIRONMENT_NAME }}
           azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -86,6 +86,7 @@ env:
   AZURE_CONTAINER_APP_ENV_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_ENV_SUBNET }}
   AZURE_CONTAINER_APP_PE_SUBNET: ${{ secrets.AZURE_CONTAINER_APP_PE_SUBNET }}
   AZURE_TAG_ENVIRONMENT_NAME: ${{ vars.AZURE_TAG_ENVIRONMENT_NAME }}
+  AZURE_ADDITIONAL_TAGS: ${{ vars.AZURE_ADDITIONAL_TAGS }}
   AZURE_INCLUDE_ROLE_ASSIGNMENTS: ${{ inputs.include_role_assignments }}
   AZURE_TURN_ON_ALERTS: ${{ inputs.turn_on_alerts || 'false' }}
   STORAGE_PROCESS_JOB_IMAGE_TAG: ${{ inputs.storage_process_image_tag || 'latest' }}
@@ -201,6 +202,7 @@ jobs:
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
           tag_environment_name: ${{ env.AZURE_TAG_ENVIRONMENT_NAME }}
+          additional_tags: ${{ env.AZURE_ADDITIONAL_TAGS }}
           azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}
@@ -246,6 +248,7 @@ jobs:
           azure_container_app_env_subnet: ${{ env.AZURE_CONTAINER_APP_ENV_SUBNET }}
           azure_container_app_pe_subnet: ${{ env.AZURE_CONTAINER_APP_PE_SUBNET }}
           tag_environment_name: ${{ env.AZURE_TAG_ENVIRONMENT_NAME }}
+          additional_tags: ${{ env.AZURE_ADDITIONAL_TAGS }}
           azure_include_role_assignments: ${{ env.AZURE_INCLUDE_ROLE_ASSIGNMENTS }}
           stack_resource_group: ${{ env.STACK_RESOURCE_GROUP }}
           deployment_name: ${{ env.DEPLOYMENT_NAME }}

--- a/infra/README.md
+++ b/infra/README.md
@@ -12,7 +12,7 @@ Shared Bicep modules live under `infra/modules`.
 
 Each stack root under `infra/stacks` is paired with a subscription-scope wrapper that creates or updates the stack-owned resource group and then deploys the stack into it.
 
-The `blob-event-processor` wrapper also supports deploying into an existing resource group and using an existing storage account. In that mode, the stack still creates its standard blob containers and storage queues, but it does not create the storage account or private endpoints for that existing account.
+The `blob-event-processor` wrapper also supports deploying into an existing resource group and using an existing storage account. In that mode, the stack still creates its standard blob containers, storage queues, private endpoints, and private DNS wiring for the configured account, but it does not create or manage the storage account service defaults.
 
 Supported deployment roots:
 

--- a/infra/modules/blob-event-processor/storage-resources.bicep
+++ b/infra/modules/blob-event-processor/storage-resources.bicep
@@ -40,6 +40,8 @@ resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2
     parent: blobService
     name: containerName
     properties: {
+      defaultEncryptionScope: '$account-encryption-key'
+      denyEncryptionScopeOverride: false
       publicAccess: 'None'
     }
   }

--- a/infra/modules/blob-event-processor/storage-resources.bicep
+++ b/infra/modules/blob-event-processor/storage-resources.bicep
@@ -31,7 +31,7 @@ var queueNames = [
   poisonQueueName
 ]
 
-resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
   name: '${storageAccountName}/default'
 }
 
@@ -45,7 +45,7 @@ resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2
   }
 ]
 
-resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' = {
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' existing = {
   name: '${storageAccountName}/default'
 }
 

--- a/infra/modules/shared/secrets.bicep
+++ b/infra/modules/shared/secrets.bicep
@@ -8,17 +8,21 @@ param environmentPrefix string
 @description('Short stack-specific suffix used to avoid cross-stack name collisions.')
 param stackNameSuffix string = ''
 
+@description('Tags that will be applied to the Key Vault')
+param tags object = {}
+
 var environmentToken = toLower(substring(environmentName, 0, environmentName == 'Production' ? 4 : 3))
 var stackNameToken = empty(stackNameSuffix) ? '' : '-${toLower(stackNameSuffix)}'
 var uniqueSuffix = take(uniqueString(subscription().subscriptionId, resourceGroup().name, environmentPrefix, environmentName, stackNameSuffix), 3)
+var keyVaultTags = union(tags, {
+  'aspire-resource-name': 'secrets'
+})
 
 // 3 - 24 alphanumeric characters
 resource secrets 'Microsoft.KeyVault/vaults@2023-07-01' = {
   name: '${environmentPrefix}-${environmentToken}${stackNameToken}-kv${uniqueSuffix}'
   location: location
-  tags: {
-    'aspire-resource-name': 'secrets'
-  }
+  tags: keyVaultTags
   properties: {
     tenantId: tenant().tenantId
     sku: {

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -46,6 +46,13 @@ Existing storage mode expects the storage account to already exist in the target
 
 Both storage modes create blob and queue private endpoints plus private DNS wiring for the configured storage account. In existing storage mode, the private endpoints target the supplied account.
 
+## Tag configuration
+
+The stack applies a common tag set to managed resources. Two optional parameters support policy-shaped environments without hard-coding those policy tags into client infrastructure:
+
+- `tagEnvironmentName` overrides the `Environment` tag value when Azure Policy expects a value that differs from `environmentName`.
+- `additionalTags` adds environment-specific tags as a JSON object. For GitHub Actions, set the repo variable `AZURE_ADDITIONAL_TAGS` to a JSON object such as `{"Service Offering":"SUI"}`. Leave it unset for client environments that should not receive DfE-specific policy tags.
+
 ## GitHub workflow behaviour
 
 The deploy workflow wraps the same subscription-scope Bicep template and adds a small amount of shell logic:
@@ -54,6 +61,8 @@ The deploy workflow wraps the same subscription-scope Bicep template and adds a 
 - validates `containerAppPeSubnet` is configured
 - validates `targetResourceGroupName` when `resourceGroupMode=existing`
 - validates `existingStorageAccountName` when `storageAccountMode=existing`
+- passes `AZURE_TAG_ENVIRONMENT_NAME` to `tagEnvironmentName` when set
+- passes `AZURE_ADDITIONAL_TAGS` to `additionalTags` when set
 - derives the stack resource group as `${environmentPrefix}-${environmentName,,}-blob-event-processor`, unless an existing resource group is supplied
 - derives the deployment name as `${resourceGroupName}-${location,,}-${mode}`
 - runs `az deployment sub what-if` or `az deployment sub create`
@@ -86,6 +95,8 @@ az deployment sub what-if \
     matchingApiImageTag=<image-tag> \
     externalApiImageTag=<image-tag> \
     turnOnAlerts=false \
+    tagEnvironmentName=<optional-environment-tag-value> \
+    additionalTags='{"Service Offering":"SUI"}' \
     resourceGroupMode=existing \
     targetResourceGroupName=<existing-resource-group-name> \
     storageAccountMode=existing \

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -64,6 +64,9 @@ param existingStorageAccountName string = ''
 @description('Optional value for the Environment tag when Azure Policy expects a different tag value than the deployment environment name.')
 param tagEnvironmentName string = ''
 
+@description('Optional additional tags to apply to deployed resources.')
+param additionalTags object = {}
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
 var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
@@ -74,14 +77,14 @@ var allowedNhsFqdns = isProductionEnvironment ? [
 ]
 var effectiveTagEnvironmentName = empty(tagEnvironmentName) ? environmentName : tagEnvironmentName
 
-var tags = {
+var baseTags = {
   'azd-env-name': environmentName
   Product: 'SUI'
   Environment: effectiveTagEnvironmentName
   EnvironmentPrefix: environmentPrefix
-  'Service Offering': 'SUI'
   Stack: 'blob-event-processor'
 }
+var tags = union(baseTags, additionalTags)
 
 module identity '../../modules/shared/identity.bicep' = {
   name: 'identity'

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -61,6 +61,9 @@ param storageAccountMode string = 'create'
 @description('The name of the existing storage account to use when storageAccountMode is existing.')
 param existingStorageAccountName string = ''
 
+@description('Optional value for the Environment tag when Azure Policy expects a different tag value than the deployment environment name.')
+param tagEnvironmentName string = ''
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
 var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
@@ -69,11 +72,12 @@ var allowedNhsFqdns = isProductionEnvironment ? [
 ] : [
   'int.api.service.nhs.uk'
 ]
+var effectiveTagEnvironmentName = empty(tagEnvironmentName) ? environmentName : tagEnvironmentName
 
 var tags = {
   'azd-env-name': environmentName
   Product: 'SUI'
-  Environment: environmentName
+  Environment: effectiveTagEnvironmentName
   EnvironmentPrefix: environmentPrefix
   'Service Offering': 'SUI'
   Stack: 'blob-event-processor'
@@ -186,6 +190,7 @@ module secrets '../../modules/shared/secrets.bicep' = {
     environmentName: environmentName
     environmentPrefix: environmentPrefix
     stackNameSuffix: stackNameSuffix
+    tags: tags
   }
 }
 

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -70,13 +70,17 @@ param storageAccountMode string = 'create'
 @description('The name of the existing storage account to use when storageAccountMode is existing.')
 param existingStorageAccountName string = ''
 
+@description('Optional value for the Environment tag when Azure Policy expects a different tag value than the deployment environment name.')
+param tagEnvironmentName string = ''
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'blob-event-processor'
 var stackResourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
 var deploymentResourceGroupName = resourceGroupMode == 'existing' ? targetResourceGroupName : stackResourceGroupName
+var effectiveTagEnvironmentName = empty(tagEnvironmentName) ? environmentName : tagEnvironmentName
 var resourceGroupTags = {
   Product: 'SUI'
-  Environment: environmentName
+  Environment: effectiveTagEnvironmentName
   EnvironmentPrefix: environmentPrefix
   'Service Offering': 'SUI'
   Stack: stackName
@@ -107,6 +111,7 @@ module stackDeployment 'main.bicep' = {
     includeRoleAssignments: includeRoleAssignments
     storageAccountMode: storageAccountMode
     existingStorageAccountName: existingStorageAccountName
+    tagEnvironmentName: tagEnvironmentName
   }
   dependsOn: [
     stackResourceGroup

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -73,18 +73,21 @@ param existingStorageAccountName string = ''
 @description('Optional value for the Environment tag when Azure Policy expects a different tag value than the deployment environment name.')
 param tagEnvironmentName string = ''
 
+@description('Optional additional tags to apply to deployed resources.')
+param additionalTags object = {}
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'blob-event-processor'
 var stackResourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
 var deploymentResourceGroupName = resourceGroupMode == 'existing' ? targetResourceGroupName : stackResourceGroupName
 var effectiveTagEnvironmentName = empty(tagEnvironmentName) ? environmentName : tagEnvironmentName
-var resourceGroupTags = {
+var baseResourceGroupTags = {
   Product: 'SUI'
   Environment: effectiveTagEnvironmentName
   EnvironmentPrefix: environmentPrefix
-  'Service Offering': 'SUI'
   Stack: stackName
 }
+var resourceGroupTags = union(baseResourceGroupTags, additionalTags)
 
 resource stackResourceGroup 'Microsoft.Resources/resourceGroups@2025-04-01' = if (resourceGroupMode == 'create') {
   name: stackResourceGroupName
@@ -112,6 +115,7 @@ module stackDeployment 'main.bicep' = {
     storageAccountMode: storageAccountMode
     existingStorageAccountName: existingStorageAccountName
     tagEnvironmentName: tagEnvironmentName
+    additionalTags: additionalTags
   }
   dependsOn: [
     stackResourceGroup


### PR DESCRIPTION
## Summary

Adds safer support for the blob-event-processor stack when using a pre-existing storage account, while reducing expected what-if noise from Azure-managed defaults and DfE policy tags.

## Changes

- Treat storage account `blobServices/default` and `queueServices/default` as existing service handles, so the stack only manages the SUI-owned containers, queues, private endpoints, DNS, and Event Grid wiring.
- Preserve default blob container properties explicitly to avoid repeated container drift in what-if output.
- Add optional tag controls for policy-shaped environments:
  - `tagEnvironmentName` lets deployments align the `Environment` tag with policy expectations.
  - `additionalTags` / `AZURE_ADDITIONAL_TAGS` lets DfE-specific tags such as `Service Offering` be supplied from repo variables instead of being hard-coded into client infrastructure.
- Pass the shared stack tags into Key Vault without replacing its required Aspire tag.
- Document existing-storage behaviour and the optional tag configuration for GitHub Actions and direct deployments.

## Validation

- Built `infra/stacks/blob-event-processor/main.bicep` with `az bicep build`.
- Built `infra/stacks/blob-event-processor/subscription.bicep` with `az bicep build`.
- Ran create-mode what-if from the branch and confirmed the storage account, containers, queues, private endpoints, and Event Grid resources are no-change.