### PR TITLE
use dotnets ImportFromPEM to import RSA

### DIFF
--- a/src/external-api/Services/StubTokenService.cs
+++ b/src/external-api/Services/StubTokenService.cs
@@ -30,7 +30,7 @@ public class StubTokenService(
                 if (string.IsNullOrEmpty(privateKey))
                 {
                     using var rsa = RSA.Create(2048);
-                    privateKey = Convert.ToBase64String(rsa.ExportRSAPrivateKey());
+                    privateKey = rsa.ExportRSAPrivateKeyPem();
                 }
                 else if (privateKey.StartsWith("file:"))
                 {

--- a/src/external-api/Util/JwtHandler.cs
+++ b/src/external-api/Util/JwtHandler.cs
@@ -53,12 +53,8 @@ public class JwtHandler : IJwtHandler
 
     private static SigningCredentials FromPrivateKey(string privateKey, string kid)
     {
-        privateKey = privateKey.Replace("-----BEGIN RSA PRIVATE KEY-----", "");
-        privateKey = privateKey.Replace("-----END RSA PRIVATE KEY-----", "");
-        var keyBytes = Convert.FromBase64String(privateKey);
-
         var rsa = RSA.Create();
-        rsa.ImportRSAPrivateKey(keyBytes, out _);
+        rsa.ImportFromPem(privateKey.ToCharArray());
 
         var rsaSecurityKey = new RsaSecurityKey(rsa) { KeyId = kid };
 

--- a/tests/Unit.Tests/External/Services/StubTokenServiceTests.cs
+++ b/tests/Unit.Tests/External/Services/StubTokenServiceTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using Azure.Security.KeyVault.Secrets;
+using ExternalApi;
+using ExternalApi.Services;
+using ExternalApi.Util;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Unit.Tests.External.Services;
+
+public class StubTokenServiceTests
+{
+    [Fact]
+    public async Task Should_ReturnBearerToken_When_StubPrivateKeyConfigurationIsEmpty()
+    {
+        // This test is proving that the stub key generated works with JwtHandler.
+
+        var handler = new MockHttpMessageHandler(
+            (_, _) =>
+                Task.FromResult(
+                    new HttpResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new StringContent("{\"access_token\":\"stub-token\"}"),
+                    }
+                )
+        );
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://auth.example.com/"),
+        };
+
+        var httpClientFactoryMock = new Mock<IHttpClientFactory>();
+        httpClientFactoryMock.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var options = Options.Create(
+            new NhsAuthConfigOptions
+            {
+                NHS_DIGITAL_CLIENT_ID = "test-client",
+                NHS_DIGITAL_KID = "test-kid",
+                NHS_DIGITAL_PRIVATE_KEY = "",
+                NHS_DIGITAL_ACCESS_TOKEN_EXPIRES_IN_MINUTES = 5,
+            }
+        );
+
+        var service = new StubTokenService(
+            options,
+            Mock.Of<ILogger<StubTokenService>>(),
+            new JwtHandler(),
+            httpClientFactoryMock.Object,
+            Mock.Of<SecretClient>()
+        );
+
+        await service.Initialise();
+
+        var token = await service.GetBearerToken();
+
+        Assert.Equal("stub-token", token);
+    }
+}


### PR DESCRIPTION
## Summary

There is a simpler way to use RSA keys with PEM, and that is a ready built method in the RSA lib `ImportFromPem` this automatically handles PEM keys. This is a marked improvement from what we had where we were manually stripping out the begin/end which is error prone if it isnt exact

## Changes

- Updated PEM method in JwtHandler to use `ImportFromPem`

## Validation

- All tests pass
- Locally ran with my own key
- Tested in a deployed environment as well
