### PR TITLE
feat: SUI-1817 - add composable storage modules

### DIFF
--- a/documentation/docs/design/infra-stack-segregation.md
+++ b/documentation/docs/design/infra-stack-segregation.md
@@ -26,7 +26,7 @@ Today the repo contains:
 
 This has been workable for the current deployment shape, but it is not a good fit for the next set of environments.
 
-The next deployment target needs a different architecture from the current VM/client shape. A future deployment is also expected to diverge further, with batch-oriented Eclipse integration as the current baseline. If we continue extending the existing single-root deployment model with more flags and conditionals, the IaC will get harder to reason about, harder to validate, and more likely to break the current deployment path.
+The next deployment target needs a different architecture from the current VM/client shape. A future deployment is also expected to diverge further, with batch-oriented GraphQL API integration as the current baseline. If we continue extending the existing single-root deployment model with more flags and conditionals, the IaC will get harder to reason about, harder to validate, and more likely to break the current deployment path.
 
 The proposed direction is to restructure deployment IaC around **separate deployment stacks by architecture pattern**, while keeping genuinely shared Azure resources in reusable modules.
 
@@ -160,7 +160,7 @@ Good candidates for shared modules:
 Poor candidates for shared modules:
 
 - anything that exists only because one deployment architecture has a different topology
-- pilot-specific VM, function, eventing, or Eclipse integration concerns
+- pilot-specific VM, function, eventing, or GraphQL API integration concerns
 - modules that only stay "shared" by introducing many boolean switches
 
 If a resource exists because one deployment architecture needs it, it should stay in that architecture's stack root.
@@ -219,7 +219,7 @@ Preserving deployability in this note means keeping the deployment path usable a
 The following assumptions are treated as current working direction:
 
 - the next environment architecture to support is the `blob-event-processor` stack
-- future Eclipse integration should be planned around the current batch model
+- future GraphQL API integration should be planned around the current batch model
 - the current deployment path must remain deployable throughout the refactor
 - Aspire should remain focused on local development rather than deployment modelling
 - generic naming should be enforced for new stacks and resources

--- a/infra/README.md
+++ b/infra/README.md
@@ -6,13 +6,15 @@ Current structure:
 
 - `client-agent`: the full DfE-hosted test architecture, composed from shared modules and client-agent-specific resources
 - `blob-event-processor`: initial deployable event-driven stack foundation, composed from shared modules plus blob/queue storage resources
-- `api-batch-processor`: placeholder isolated stack root for the future batch-oriented architecture
+- `api-batch-processor`: isolated stack root for the future batch-oriented architecture, currently provisioning blob storage for low-confidence match output
 
 Shared Bicep modules live under `infra/modules`.
 
+Reusable storage modules under `infra/modules/shared` separate storage account creation, blob containers, queues, and storage private endpoint/DNS wiring so new stacks can compose only the storage resources they need.
+
 Each stack root under `infra/stacks` is paired with a subscription-scope wrapper that creates or updates the stack-owned resource group and then deploys the stack into it.
 
-The `blob-event-processor` wrapper also supports deploying into an existing resource group and using an existing storage account. In that mode, the stack still creates its standard blob containers, storage queues, private endpoints, and private DNS wiring for the configured account, but it does not create or manage the storage account service defaults.
+The `blob-event-processor` wrapper also supports deploying into an existing resource group and using an existing storage account. In that mode, the stack still creates its standard blob containers, storage queues, private endpoints, and private DNS wiring for the configured account, but it does not create or manage the storage account service defaults. Its deployed storage, queue, Event Grid, private endpoint, and DNS resource set is intentionally preserved.
 
 Supported deployment roots:
 

--- a/infra/modules/blob-event-processor/storage-resources.bicep
+++ b/infra/modules/blob-event-processor/storage-resources.bicep
@@ -31,142 +31,35 @@ var queueNames = [
   poisonQueueName
 ]
 
-resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
-  name: '${storageAccountName}/default'
+module blobContainers '../shared/storage-blob-containers.bicep' = {
+  name: 'blob-event-processor-storage-containers'
+  params: {
+    storageAccountName: storageAccountName
+    containerNames: containerNames
+  }
 }
 
-resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = [
-  for containerName in containerNames: {
-    parent: blobService
-    name: containerName
-    properties: {
-      defaultEncryptionScope: '$account-encryption-key'
-      denyEncryptionScopeOverride: false
-      publicAccess: 'None'
-    }
+module storageQueues '../shared/storage-queues.bicep' = {
+  name: 'blob-event-processor-storage-queues'
+  params: {
+    storageAccountName: storageAccountName
+    queueNames: queueNames
   }
-]
-
-resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' existing = {
-  name: '${storageAccountName}/default'
 }
 
-resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = [
-  for currentQueueName in queueNames: {
-    parent: queueService
-    name: currentQueueName
-  }
-]
-
-resource blobPrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
-  name: '${storageAccountName}-blob-pe'
-  location: location
-  tags: tags
-  properties: {
-    subnet: {
-      id: peSubnetId
-    }
-    privateLinkServiceConnections: [
-      {
-        name: '${storageAccountName}-blob-pe-conn'
-        properties: {
-          privateLinkServiceId: storageAccountId
-          groupIds: [
-            'blob'
-          ]
-        }
-      }
+module storagePrivateEndpoints '../shared/storage-private-endpoints.bicep' = {
+  name: 'blob-event-processor-storage-private-endpoints'
+  params: {
+    location: location
+    tags: tags
+    storageAccountName: storageAccountName
+    storageAccountId: storageAccountId
+    storageServices: [
+      'blob'
+      'queue'
     ]
-  }
-}
-
-resource queuePrivateEndpoint 'Microsoft.Network/privateEndpoints@2023-05-01' = {
-  name: '${storageAccountName}-queue-pe'
-  location: location
-  tags: tags
-  properties: {
-    subnet: {
-      id: peSubnetId
-    }
-    privateLinkServiceConnections: [
-      {
-        name: '${storageAccountName}-queue-pe-conn'
-        properties: {
-          privateLinkServiceId: storageAccountId
-          groupIds: [
-            'queue'
-          ]
-        }
-      }
-    ]
-  }
-}
-
-resource blobDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: 'privatelink.blob.${environment().suffixes.storage}'
-  location: 'global'
-  tags: tags
-}
-
-resource queueDnsZone 'Microsoft.Network/privateDnsZones@2020-06-01' = {
-  name: 'privatelink.queue.${environment().suffixes.storage}'
-  location: 'global'
-  tags: tags
-}
-
-resource blobDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  parent: blobDnsZone
-  name: '${storageAccountName}-blob-dns-link'
-  location: 'global'
-  tags: tags
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnetId
-    }
-  }
-}
-
-resource queueDnsZoneLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = {
-  parent: queueDnsZone
-  name: '${storageAccountName}-queue-dns-link'
-  location: 'global'
-  tags: tags
-  properties: {
-    registrationEnabled: false
-    virtualNetwork: {
-      id: vnetId
-    }
-  }
-}
-
-resource blobDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
-  parent: blobPrivateEndpoint
-  name: 'default'
-  properties: {
-    privateDnsZoneConfigs: [
-      {
-        name: replace(blobDnsZone.name, '.', '-')
-        properties: {
-          privateDnsZoneId: blobDnsZone.id
-        }
-      }
-    ]
-  }
-}
-
-resource queueDnsZoneGroup 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = {
-  parent: queuePrivateEndpoint
-  name: 'default'
-  properties: {
-    privateDnsZoneConfigs: [
-      {
-        name: replace(queueDnsZone.name, '.', '-')
-        properties: {
-          privateDnsZoneId: queueDnsZone.id
-        }
-      }
-    ]
+    peSubnetId: peSubnetId
+    vnetId: vnetId
   }
 }
 

--- a/infra/modules/blob-event-processor/storage.bicep
+++ b/infra/modules/blob-event-processor/storage.bicep
@@ -19,25 +19,12 @@ param vnetId string
 var noHyphensEnvironmentPrefix = replace(environmentPrefix, '-', '')
 var storageAccountName = toLower('${take(noHyphensEnvironmentPrefix, 8)}${take(lowercaseEnvironmentName, 8)}bep${take(uniqueString(resourceGroup().id, noHyphensEnvironmentPrefix, lowercaseEnvironmentName), 5)}')
 
-resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
-  name: storageAccountName
-  location: location
-  kind: 'StorageV2'
-  sku: {
-    name: 'Standard_LRS'
-  }
-  tags: tags
-  properties: {
-    accessTier: 'Hot'
-    allowBlobPublicAccess: false
-    allowSharedKeyAccess: true
-    minimumTlsVersion: 'TLS1_2'
-    publicNetworkAccess: 'Enabled' // Must be Enabled to allow Trusted Microsoft Services when networkAcls are used
-    supportsHttpsTrafficOnly: true
-    networkAcls: {
-      bypass: 'AzureServices'
-      defaultAction: 'Deny'
-    }
+module storageAccount '../shared/storage-account.bicep' = {
+  name: 'blob-event-processor-storage-account'
+  params: {
+    location: location
+    storageAccountName: storageAccountName
+    tags: tags
   }
 }
 
@@ -46,17 +33,17 @@ module storageResources './storage-resources.bicep' = {
   params: {
     location: location
     tags: tags
-    storageAccountName: storageAccount.name
-    storageAccountId: storageAccount.id
+    storageAccountName: storageAccount.outputs.accountName
+    storageAccountId: storageAccount.outputs.accountId
     peSubnetId: peSubnetId
     vnetId: vnetId
   }
 }
 
-output accountName string = storageAccount.name
-output accountId string = storageAccount.id
-output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
-output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue
+output accountName string = storageAccount.outputs.accountName
+output accountId string = storageAccount.outputs.accountId
+output blobEndpoint string = storageAccount.outputs.blobEndpoint
+output queueEndpoint string = storageAccount.outputs.queueEndpoint
 output incomingContainerName string = storageResources.outputs.incomingContainerName
 output processedContainerName string = storageResources.outputs.processedContainerName
 output successContainerName string = storageResources.outputs.successContainerName

--- a/infra/modules/shared/storage-account.bicep
+++ b/infra/modules/shared/storage-account.bicep
@@ -1,0 +1,37 @@
+@description('The location used for the storage account')
+param location string
+
+@minLength(3)
+@maxLength(24)
+@description('The globally unique name of the storage account')
+param storageAccountName string
+
+@description('Tags that will be applied to the storage account')
+param tags object = {}
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  tags: tags
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    allowSharedKeyAccess: true
+    minimumTlsVersion: 'TLS1_2'
+    publicNetworkAccess: 'Enabled' // Must be Enabled to allow Trusted Microsoft Services when networkAcls are used
+    supportsHttpsTrafficOnly: true
+    networkAcls: {
+      bypass: 'AzureServices'
+      defaultAction: 'Deny'
+    }
+  }
+}
+
+output accountName string = storageAccount.name
+output accountId string = storageAccount.id
+output blobEndpoint string = storageAccount.properties.primaryEndpoints.blob
+output queueEndpoint string = storageAccount.properties.primaryEndpoints.queue

--- a/infra/modules/shared/storage-blob-containers.bicep
+++ b/infra/modules/shared/storage-blob-containers.bicep
@@ -1,0 +1,21 @@
+@description('The name of the storage account to configure')
+param storageAccountName string
+
+@description('Blob container names to create')
+param containerNames array
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
+  name: '${storageAccountName}/default'
+}
+
+resource containers 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = [
+  for containerName in containerNames: {
+    parent: blobService
+    name: containerName
+    properties: {
+      defaultEncryptionScope: '$account-encryption-key'
+      denyEncryptionScopeOverride: false
+      publicAccess: 'None'
+    }
+  }
+]

--- a/infra/modules/shared/storage-private-endpoints.bicep
+++ b/infra/modules/shared/storage-private-endpoints.bicep
@@ -1,0 +1,88 @@
+@description('The location used for all deployed resources')
+param location string
+
+@description('Tags that will be applied to all resources')
+param tags object = {}
+
+@description('The name of the storage account to connect to')
+param storageAccountName string
+
+@description('The resource ID of the storage account to connect to')
+param storageAccountId string
+
+@description('Storage service group IDs to expose privately, such as blob or queue')
+param storageServices array
+
+@description('The resource ID of the subnet for private endpoints')
+param peSubnetId string
+
+@description('The resource ID of the virtual network for private DNS zone links')
+param vnetId string
+
+var dnsZoneNames = [
+  for storageService in storageServices: 'privatelink.${storageService}.${environment().suffixes.storage}'
+]
+
+resource privateEndpoints 'Microsoft.Network/privateEndpoints@2023-05-01' = [
+  for storageService in storageServices: {
+    name: '${storageAccountName}-${storageService}-pe'
+    location: location
+    tags: tags
+    properties: {
+      subnet: {
+        id: peSubnetId
+      }
+      privateLinkServiceConnections: [
+        {
+          name: '${storageAccountName}-${storageService}-pe-conn'
+          properties: {
+            privateLinkServiceId: storageAccountId
+            groupIds: [
+              storageService
+            ]
+          }
+        }
+      ]
+    }
+  }
+]
+
+resource dnsZones 'Microsoft.Network/privateDnsZones@2020-06-01' = [
+  for dnsZoneName in dnsZoneNames: {
+    name: dnsZoneName
+    location: 'global'
+    tags: tags
+  }
+]
+
+resource dnsZoneLinks 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01' = [
+  for (storageService, serviceIndex) in storageServices: {
+    parent: dnsZones[serviceIndex]
+    name: '${storageAccountName}-${storageService}-dns-link'
+    location: 'global'
+    tags: tags
+    properties: {
+      registrationEnabled: false
+      virtualNetwork: {
+        id: vnetId
+      }
+    }
+  }
+]
+
+resource dnsZoneGroups 'Microsoft.Network/privateEndpoints/privateDnsZoneGroups@2023-05-01' = [
+  for (dnsZoneName, serviceIndex) in dnsZoneNames: {
+    parent: privateEndpoints[serviceIndex]
+    name: 'default'
+    properties: {
+      privateDnsZoneConfigs: [
+        {
+          name: replace(dnsZoneName, '.', '-')
+          properties: {
+            privateDnsZoneId: dnsZones[serviceIndex].id
+          }
+        }
+      ]
+    }
+  }
+]

--- a/infra/modules/shared/storage-queues.bicep
+++ b/infra/modules/shared/storage-queues.bicep
@@ -1,0 +1,16 @@
+@description('The name of the storage account to configure')
+param storageAccountName string
+
+@description('Storage queue names to create')
+param queueNames array
+
+resource queueService 'Microsoft.Storage/storageAccounts/queueServices@2023-05-01' existing = {
+  name: '${storageAccountName}/default'
+}
+
+resource queues 'Microsoft.Storage/storageAccounts/queueServices/queues@2023-05-01' = [
+  for queueName in queueNames: {
+    parent: queueService
+    name: queueName
+  }
+]

--- a/infra/stacks/api-batch-processor/README.md
+++ b/infra/stacks/api-batch-processor/README.md
@@ -1,9 +1,19 @@
 # Api-Batch-Processor Stack
 
-This is the placeholder root for the planned batch-oriented architecture.
+This is the root for the planned batch-oriented architecture.
 
 It exists to reserve the stack boundary and deployment contract without introducing any dependency on `client-agent`.
 
 `infra/stacks/api-batch-processor/subscription.bicep` is the stack-owned resource-group entrypoint for this stack, although no dedicated deploy workflow exists yet.
 
-Follow-up work should add the scheduled processing, external API integration, identity, secret, and networking resources required by this architecture directly to this stack.
+Current scope:
+
+- storage account for low-confidence match output
+- blob private endpoint for storage access from the stack virtual network
+- blob private DNS zone and virtual network link
+
+The stack deliberately does not create Event Grid resources, storage queues, queue private endpoints, or queue private DNS. High-confidence matches are expected to be sent directly back to a GraphQL API by later application work.
+
+The subscription entrypoint requires `containerAppVnet` and `containerAppPeSubnet` so the blob private endpoint can be placed in the stack virtual network.
+
+Follow-up work should add the scheduled processing, external API integration, identity, secret, and remaining networking resources required by this architecture directly to this stack.

--- a/infra/stacks/api-batch-processor/main.bicep
+++ b/infra/stacks/api-batch-processor/main.bicep
@@ -11,6 +11,18 @@ param environmentPrefix string
 @description('The location used for all deployed resources')
 param location string = resourceGroup().location
 
+@minLength(1)
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@minLength(1)
+@description('The address prefix for the private endpoint subnet')
+param containerAppPeSubnet string
+
+var lowercaseEnvironmentName = toLower(environmentName)
+var stackNameSuffix = 'abp'
+var noHyphensEnvironmentPrefix = replace(environmentPrefix, '-', '')
+var storageAccountName = toLower('${take(noHyphensEnvironmentPrefix, 8)}${take(lowercaseEnvironmentName, 8)}${stackNameSuffix}${take(uniqueString(resourceGroup().id, noHyphensEnvironmentPrefix, lowercaseEnvironmentName), 5)}')
 var tags = {
   Product: 'SUI'
   Environment: environmentName
@@ -19,8 +31,46 @@ var tags = {
   Stack: 'api-batch-processor'
 }
 
-// Placeholder stack root. Architecture-specific resources will be added in follow-up tickets.
+module storage '../../modules/shared/storage-account.bicep' = {
+  name: 'api-batch-processor-storage'
+  params: {
+    location: location
+    storageAccountName: storageAccountName
+    tags: tags
+  }
+}
+
+module containerAppNetwork '../../modules/shared/container-app-network.bicep' = {
+  name: 'container-app-network'
+  params: {
+    location: location
+    environmentPrefix: environmentPrefix
+    lowercaseEnvironmentName: lowercaseEnvironmentName
+    stackNameSuffix: stackNameSuffix
+    containerAppVnet: containerAppVnet
+    privateEndpointSubnetAddressPrefix: containerAppPeSubnet
+    tags: tags
+  }
+}
+
+module storagePrivateEndpoint '../../modules/shared/storage-private-endpoints.bicep' = {
+  name: 'api-batch-processor-storage-private-endpoint'
+  params: {
+    location: location
+    tags: tags
+    storageAccountName: storage.outputs.accountName
+    storageAccountId: storage.outputs.accountId
+    storageServices: [
+      'blob'
+    ]
+    peSubnetId: containerAppNetwork.outputs.privateEndpointSubnetId
+    vnetId: containerAppNetwork.outputs.virtualNetworkId
+  }
+}
+
 output STACK_NAME string = 'api-batch-processor'
-output STACK_CONTRACT_STATUS string = 'placeholder'
 output LOCATION string = location
 output TAGS object = tags
+output STORAGE_ACCOUNT_NAME string = storage.outputs.accountName
+output STORAGE_ACCOUNT_ID string = storage.outputs.accountId
+output STORAGE_BLOB_ENDPOINT string = storage.outputs.blobEndpoint

--- a/infra/stacks/api-batch-processor/subscription.bicep
+++ b/infra/stacks/api-batch-processor/subscription.bicep
@@ -11,6 +11,14 @@ param environmentPrefix string
 @description('The location used for all deployed resources')
 param location string
 
+@minLength(1)
+@description('The address prefix for the virtual network')
+param containerAppVnet string
+
+@minLength(1)
+@description('The address prefix for the private endpoint subnet')
+param containerAppPeSubnet string
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'api-batch-processor'
 var resourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
@@ -35,12 +43,16 @@ module stackDeployment 'main.bicep' = {
     environmentName: environmentName
     environmentPrefix: environmentPrefix
     location: location
+    containerAppVnet: containerAppVnet
+    containerAppPeSubnet: containerAppPeSubnet
   }
 }
 
 output RESOURCE_GROUP_NAME string = stackResourceGroup.name
 output RESOURCE_GROUP_ID string = stackResourceGroup.id
 output STACK_NAME string = stackDeployment.outputs.STACK_NAME
-output STACK_CONTRACT_STATUS string = stackDeployment.outputs.STACK_CONTRACT_STATUS
 output LOCATION string = stackDeployment.outputs.LOCATION
 output TAGS object = stackDeployment.outputs.TAGS
+output STORAGE_ACCOUNT_NAME string = stackDeployment.outputs.STORAGE_ACCOUNT_NAME
+output STORAGE_ACCOUNT_ID string = stackDeployment.outputs.STORAGE_ACCOUNT_ID
+output STORAGE_BLOB_ENDPOINT string = stackDeployment.outputs.STORAGE_BLOB_ENDPOINT

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -29,6 +29,8 @@ It can also deploy into an existing resource group by setting:
 
 The default storage mode is `storageAccountMode=create`. In this mode the stack creates the storage account, the blob/queue containers, and the blob/queue private endpoints and private DNS wiring.
 
+The storage implementation uses shared composable modules internally, but the deployed resource set for this stack remains the full event-driven storage surface: storage account, containers, queues, Event Grid, blob and queue private endpoints, and blob and queue private DNS.
+
 Created storage accounts use Standard LRS hot storage, disable blob public access, require TLS 1.2, and deny network access except for trusted Azure services.
 
 For client-provided storage, set:


### PR DESCRIPTION
## Summary

The `api-batch-processor` stack needs differing storage resources. This PR extracts the existing `blob-event-processor` storage definitions into reusable shared Bicep modules, then uses those modules to add the initial storage and network wiring for `api-batch-processor`.

The `blob-event-processor` resource names and desired storage configuration are preserved.

## Changes

- add shared modules for storage accounts, blob containers, queues, and storage private endpoints
- refactor `blob-event-processor` storage resources to consume the shared modules
- add an `api-batch-processor` storage account, blob private endpoint, virtual network wiring, parameters, and outputs
- update the relevant infrastructure and stack documentation

## Validation

- built `infra/stacks/blob-event-processor/main.bicep`
- built `infra/stacks/api-batch-processor/main.bicep`
- built `infra/stacks/api-batch-processor/subscription.bicep`
- ran a live `blob-event-processor` what-if against existing client deployment
- compared the current branch what-if with `origin/main`; resource change types and outputs were identical
- confirmed the existing storage account, containers, queues, private endpoints, DNS zones, and DNS links remain unchanged
