### PR TITLE
feat: SUI-1847 - support configurable reconciliation storage jobs

### DIFF
--- a/.github/actions/stack-infra-run/action.yml
+++ b/.github/actions/stack-infra-run/action.yml
@@ -104,6 +104,10 @@ inputs:
     description: "Optional existing storage account name when storage_account_mode is existing"
     required: false
     default: ""
+  storage_process_job_configuration:
+    description: "Optional JSON object containing protected storage process job runtime configuration"
+    required: false
+    default: ""
 
 
 runs:
@@ -127,6 +131,7 @@ runs:
       shell: bash
       env:
         ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
+        STORAGE_PROCESS_JOB_CONFIGURATION: ${{ inputs.storage_process_job_configuration }}
       run: |
         set -euo pipefail
 
@@ -164,6 +169,11 @@ runs:
         if [ -n "${ADDITIONAL_TAGS}" ]; then
           ADDITIONAL_TAGS_JSON="$(jq -nce --argjson tags "${ADDITIONAL_TAGS}" 'if ($tags | type) == "object" then $tags else error("additional_tags must be a JSON object") end')"
           PARAMETERS+=("additionalTags=${ADDITIONAL_TAGS_JSON}")
+        fi
+
+        if [ -n "${STORAGE_PROCESS_JOB_CONFIGURATION}" ]; then
+          STORAGE_PROCESS_JOB_CONFIGURATION_JSON="$(jq -nce --argjson configuration "${STORAGE_PROCESS_JOB_CONFIGURATION}" 'if ($configuration | type) == "object" then $configuration else error("storage_process_job_configuration must be a JSON object") end')"
+          PARAMETERS+=("storageProcessJobConfiguration=${STORAGE_PROCESS_JOB_CONFIGURATION_JSON}")
         fi
 
         if [ -n "${{ inputs.turn_on_alerts }}" ]; then

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -96,6 +96,7 @@ env:
   TARGET_RESOURCE_GROUP_NAME: ${{ inputs.target_resource_group_name }}
   STORAGE_ACCOUNT_MODE: ${{ inputs.storage_account_mode || 'create' }}
   EXISTING_STORAGE_ACCOUNT_NAME: ${{ inputs.existing_storage_account_name }}
+  # Column mappings may identify a specific deployment, so keep them in secrets to avoid leaking them in workflow logs.
   STORAGE_PROCESS_JOB_CONFIGURATION: ${{ secrets.STORAGE_PROCESS_JOB_CONFIGURATION }}
 
 concurrency:
@@ -124,6 +125,15 @@ jobs:
 
           if [ -z "${AZURE_CONTAINER_APP_PE_SUBNET}" ]; then
             echo "::error::AZURE_CONTAINER_APP_PE_SUBNET secret must be configured for blob-event-processor infrastructure deployments."
+            exit 1
+          fi
+
+      - name: Validate storage process job configuration
+        run: |
+          set -euo pipefail
+
+          if [ -z "${STORAGE_PROCESS_JOB_CONFIGURATION}" ]; then
+            echo "::error::STORAGE_PROCESS_JOB_CONFIGURATION secret must be configured for blob-event-processor infrastructure deployments."
             exit 1
           fi
 

--- a/.github/workflows/gh-blob-event-processor-infra-deploy.yml
+++ b/.github/workflows/gh-blob-event-processor-infra-deploy.yml
@@ -96,6 +96,7 @@ env:
   TARGET_RESOURCE_GROUP_NAME: ${{ inputs.target_resource_group_name }}
   STORAGE_ACCOUNT_MODE: ${{ inputs.storage_account_mode || 'create' }}
   EXISTING_STORAGE_ACCOUNT_NAME: ${{ inputs.existing_storage_account_name }}
+  STORAGE_PROCESS_JOB_CONFIGURATION: ${{ secrets.STORAGE_PROCESS_JOB_CONFIGURATION }}
 
 concurrency:
   group: blob-event-processor-${{ inputs.environment_prefix }}-${{ inputs.environment }}
@@ -214,6 +215,7 @@ jobs:
           target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
           storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}
           existing_storage_account_name: ${{ env.EXISTING_STORAGE_ACCOUNT_NAME }}
+          storage_process_job_configuration: ${{ env.STORAGE_PROCESS_JOB_CONFIGURATION }}
 
   deploy:
     name: Deploy blob-event-processor infrastructure
@@ -260,6 +262,7 @@ jobs:
           target_resource_group_name: ${{ env.TARGET_RESOURCE_GROUP_NAME }}
           storage_account_mode: ${{ env.STORAGE_ACCOUNT_MODE }}
           existing_storage_account_name: ${{ env.EXISTING_STORAGE_ACCOUNT_NAME }}
+          storage_process_job_configuration: ${{ env.STORAGE_PROCESS_JOB_CONFIGURATION }}
 
   summarize:
     name: Summarize blob-event-processor run

--- a/.github/workflows/gh-blob-event-processor-storage-job-image.yml
+++ b/.github/workflows/gh-blob-event-processor-storage-job-image.yml
@@ -120,16 +120,6 @@ jobs:
             --image "${IMAGE_REPOSITORY}:latest" \
             --file src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile \
             --build-arg MATCH_API_BASE_ADDRESS="${{ steps.context.outputs.match_api_base_address }}" \
-            --build-arg CSV_DATE_FORMAT=yyyy-MM-dd \
-            --build-arg CSV_COLUMN_ID=Id \
-            --build-arg CSV_COLUMN_GIVEN=GivenName \
-            --build-arg CSV_COLUMN_FAMILY=FamilyName \
-            --build-arg CSV_COLUMN_BIRTH_DATE=DOB \
-            --build-arg CSV_COLUMN_EMAIL=EMAIL \
-            --build-arg CSV_COLUMN_POSTCODE=POSTCODE \
-            --build-arg CSV_COLUMN_GENDER=GENDER \
-            --build-arg CSV_COLUMN_PHONE=PHONE \
-            --build-arg CSV_COLUMN_NHS_NUMBER=NHS_NUMBER \
             .
 
       - name: Write workflow summary

--- a/documentation/docs/runbooks/blob-processor-local-runbook.md
+++ b/documentation/docs/runbooks/blob-processor-local-runbook.md
@@ -105,6 +105,8 @@ STORAGE_ACCOUNT_MODE="create" # "create" or "existing"
 EXISTING_STORAGE_ACCOUNT_NAME="" # Leave blank if it does not exist.
 AZURE_TAG_ENVIRONMENT_NAME="" # Optional override for the Environment tag.
 AZURE_ADDITIONAL_TAGS="{}" # Optional additional tags as a JSON object string.
+# Obtain this protected JSON object from the approved external runbook.
+STORAGE_PROCESS_JOB_CONFIGURATION="{}"
 ```
 
 Load the variables into your terminal session, derive the common deployment values, and select the Azure subscription:
@@ -174,6 +176,7 @@ Required variables:
 - `EXTERNAL_API_IMAGE_TAG`
 - `STORAGE_ACCOUNT_MODE`
 - `EXISTING_STORAGE_ACCOUNT_NAME` when `STORAGE_ACCOUNT_MODE` is `existing`
+- `STORAGE_PROCESS_JOB_CONFIGURATION`
 
 Optional variables:
 
@@ -234,6 +237,7 @@ az deployment group what-if \
     externalApiImageTag="${EXTERNAL_API_IMAGE_TAG}" \
     storageAccountMode="${STORAGE_ACCOUNT_MODE}" \
     existingStorageAccountName="${EXISTING_STORAGE_ACCOUNT_NAME}" \
+    storageProcessJobConfiguration="${STORAGE_PROCESS_JOB_CONFIGURATION}" \
     tagEnvironmentName="${AZURE_TAG_ENVIRONMENT_NAME}" \
     additionalTags="${AZURE_ADDITIONAL_TAGS}"
 ```
@@ -277,6 +281,7 @@ az deployment group create \
     externalApiImageTag="${EXTERNAL_API_IMAGE_TAG}" \
     storageAccountMode="${STORAGE_ACCOUNT_MODE}" \
     existingStorageAccountName="${EXISTING_STORAGE_ACCOUNT_NAME}" \
+    storageProcessJobConfiguration="${STORAGE_PROCESS_JOB_CONFIGURATION}" \
     tagEnvironmentName="${AZURE_TAG_ENVIRONMENT_NAME}" \
     additionalTags="${AZURE_ADDITIONAL_TAGS}"
 ```
@@ -457,18 +462,10 @@ az acr build \
   --image "${IMAGE_REPOSITORY}:latest" \
   --file src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile \
   --build-arg MATCH_API_BASE_ADDRESS="${MATCH_API_BASE_ADDRESS}" \
-  --build-arg CSV_DATE_FORMAT=yyyy-MM-dd \
-  --build-arg CSV_COLUMN_ID=Id \
-  --build-arg CSV_COLUMN_GIVEN=GivenName \
-  --build-arg CSV_COLUMN_FAMILY=FamilyName \
-  --build-arg CSV_COLUMN_BIRTH_DATE=DOB \
-  --build-arg CSV_COLUMN_EMAIL=EMAIL \
-  --build-arg CSV_COLUMN_POSTCODE=POSTCODE \
-  --build-arg CSV_COLUMN_GENDER=GENDER \
-  --build-arg CSV_COLUMN_PHONE=PHONE \
-  --build-arg CSV_COLUMN_NHS_NUMBER=NHS_NUMBER \
   .
 ```
+
+CSV mappings and processing mode are runtime deployment configuration. Obtain the protected configuration from the approved external runbook; do not add its values to this repository or image build command.
 
 Check that the repository contains the current Git commit hash and `latest` tags:
 
@@ -504,6 +501,7 @@ Required variables for this task:
 - `AZURE_TURN_ON_ALERTS`
 - `STORAGE_ACCOUNT_MODE`
 - `EXISTING_STORAGE_ACCOUNT_NAME` when `STORAGE_ACCOUNT_MODE` is `existing`
+- `STORAGE_PROCESS_JOB_CONFIGURATION`
 - `EXTERNAL_API_IMAGE_TAG`
 - `MATCHING_API_IMAGE_TAG`
 - `STORAGE_PROCESS_JOB_IMAGE_TAG`

--- a/documentation/docs/runbooks/blob-processor-local-runbook.md
+++ b/documentation/docs/runbooks/blob-processor-local-runbook.md
@@ -106,8 +106,10 @@ EXISTING_STORAGE_ACCOUNT_NAME="" # Leave blank if it does not exist.
 AZURE_TAG_ENVIRONMENT_NAME="" # Optional override for the Environment tag.
 AZURE_ADDITIONAL_TAGS="{}" # Optional additional tags as a JSON object string.
 # Obtain this protected JSON object from the approved external runbook.
-STORAGE_PROCESS_JOB_CONFIGURATION="{}"
+STORAGE_PROCESS_JOB_CONFIGURATION='<protected-storage-process-job-configuration-json>'
 ```
+
+`STORAGE_PROCESS_JOB_CONFIGURATION` is passed to the ACA job as runtime environment configuration. It must include the storage job processing mode and CSV mapping keys before the storage processor can process files. Keep deployment-specific source column names in the approved external runbook, not in this repository.
 
 Load the variables into your terminal session, derive the common deployment values, and select the Azure subscription:
 
@@ -466,6 +468,8 @@ az acr build \
 ```
 
 CSV mappings and processing mode are runtime deployment configuration. Obtain the protected configuration from the approved external runbook; do not add its values to this repository or image build command.
+
+Do not smoke test a newly published storage processor image until `STORAGE_PROCESS_JOB_CONFIGURATION` has been set for the target environment. The image no longer contains default source column mappings.
 
 Check that the repository contains the current Git commit hash and `latest` tags:
 

--- a/infra/modules/blob-event-processor/container-app-job.bicep
+++ b/infra/modules/blob-event-processor/container-app-job.bicep
@@ -44,8 +44,8 @@ param imageTag string
 param matchApiBaseAddress string
 
 @secure()
-@description('Optional runtime configuration values for the storage process job.')
-param storageProcessJobConfiguration object = {}
+@description('Runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object
 
 @description('Tags that will be applied to all resources')
 param tags object = {}

--- a/infra/modules/blob-event-processor/container-app-job.bicep
+++ b/infra/modules/blob-event-processor/container-app-job.bicep
@@ -43,6 +43,10 @@ param imageTag string
 @description('The base address of the matching API')
 param matchApiBaseAddress string
 
+@secure()
+@description('Optional runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object = {}
+
 @description('Tags that will be applied to all resources')
 param tags object = {}
 
@@ -54,6 +58,10 @@ param includeRoleAssignments bool = true
 var jobName = toLower('${take(environmentPrefix, 8)}-${take(lowercaseEnvironmentName, 3)}-storage-process-job')
 var storageBlobDataContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
 var storageQueueDataContributorRoleId = '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+var storageProcessJobConfigurationEnvironment = [for setting in items(storageProcessJobConfiguration): {
+  name: setting.key
+  value: string(setting.value)
+}]
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
   name: storageAccountName
@@ -133,28 +141,31 @@ resource storageProcessJob 'Microsoft.App/jobs@2024-10-02-preview' = {
             cpu: json('2.0')
             memory: '4Gi'
           }
-          env: [
-            {
-              name: 'StorageProcessJob__BlobServiceUri'
-              value: blobServiceUri
-            }
-            {
-              name: 'StorageProcessJob__QueueServiceUri'
-              value: queueServiceUri
-            }
-            {
-              name: 'StorageProcessJob__MatchApiBaseAddress'
-              value: matchApiBaseAddress
-            }
-            {
-              name: 'StorageProcessJob__MaxDequeueCount'
-              value: '1'
-            }
-            {
-              name: 'AZURE_CLIENT_ID'
-              value: managedIdentityClientId
-            }
-          ]
+          env: concat(
+            [
+              {
+                name: 'StorageProcessJob__BlobServiceUri'
+                value: blobServiceUri
+              }
+              {
+                name: 'StorageProcessJob__QueueServiceUri'
+                value: queueServiceUri
+              }
+              {
+                name: 'StorageProcessJob__MatchApiBaseAddress'
+                value: matchApiBaseAddress
+              }
+              {
+                name: 'StorageProcessJob__MaxDequeueCount'
+                value: '1'
+              }
+              {
+                name: 'AZURE_CLIENT_ID'
+                value: managedIdentityClientId
+              }
+            ],
+            storageProcessJobConfigurationEnvironment
+          )
         }
       ]
     }

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -119,6 +119,8 @@ It uses the shared managed identity, pulls `sui-client-storage-process-job:<tag>
 
 The job is configured with 2 vCPU, 4Gi memory, a 6 hour replica timeout, no automatic replica retries, and `StorageProcessJob__MaxDequeueCount=1`.
 
+CSV mappings and processing mode are supplied as a protected JSON object through the `STORAGE_PROCESS_JOB_CONFIGURATION` GitHub environment secret. The object keys are .NET environment-variable configuration names. Do not put deployment-specific schemas or mapping values in repository files, workflow inputs, or workflow summaries.
+
 ### Azure Storage blob and queues
 
 Setup of azure storage blob for file upload for processing.

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -122,6 +122,8 @@ The job is configured with 2 vCPU, 4Gi memory, a 6 hour replica timeout, no auto
 
 CSV mappings and processing mode are supplied as a protected JSON object through the `STORAGE_PROCESS_JOB_CONFIGURATION` GitHub environment secret, or through the `storageProcessJobConfiguration` Bicep parameter for direct CLI deployments. The object keys are .NET environment-variable configuration names. Do not put deployment-specific schemas or mapping values in repository files, workflow inputs, or workflow summaries.
 
+Include `CsvMatchData__AddressHistoryFormat` when source address history uses a non-default parser format, such as `SemicolonCommaNewestFirst`.
+
 ### Azure Storage blob and queues
 
 Setup of azure storage blob for file upload for processing.

--- a/infra/stacks/blob-event-processor/README.md
+++ b/infra/stacks/blob-event-processor/README.md
@@ -99,6 +99,7 @@ az deployment sub what-if \
     turnOnAlerts=false \
     tagEnvironmentName=<optional-environment-tag-value> \
     additionalTags='{"Service Offering":"SUI"}' \
+    storageProcessJobConfiguration='<protected-storage-process-job-configuration-json>' \
     resourceGroupMode=existing \
     targetResourceGroupName=<existing-resource-group-name> \
     storageAccountMode=existing \
@@ -119,7 +120,7 @@ It uses the shared managed identity, pulls `sui-client-storage-process-job:<tag>
 
 The job is configured with 2 vCPU, 4Gi memory, a 6 hour replica timeout, no automatic replica retries, and `StorageProcessJob__MaxDequeueCount=1`.
 
-CSV mappings and processing mode are supplied as a protected JSON object through the `STORAGE_PROCESS_JOB_CONFIGURATION` GitHub environment secret. The object keys are .NET environment-variable configuration names. Do not put deployment-specific schemas or mapping values in repository files, workflow inputs, or workflow summaries.
+CSV mappings and processing mode are supplied as a protected JSON object through the `STORAGE_PROCESS_JOB_CONFIGURATION` GitHub environment secret, or through the `storageProcessJobConfiguration` Bicep parameter for direct CLI deployments. The object keys are .NET environment-variable configuration names. Do not put deployment-specific schemas or mapping values in repository files, workflow inputs, or workflow summaries.
 
 ### Azure Storage blob and queues
 

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -68,8 +68,8 @@ param tagEnvironmentName string = ''
 param additionalTags object = {}
 
 @secure()
-@description('Optional runtime configuration values for the storage process job.')
-param storageProcessJobConfiguration object = {}
+@description('Runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -67,6 +67,10 @@ param tagEnvironmentName string = ''
 @description('Optional additional tags to apply to deployed resources.')
 param additionalTags object = {}
 
+@secure()
+@description('Optional runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object = {}
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackNameSuffix = 'bep'
 var isProductionEnvironment = lowercaseEnvironmentName == 'prod' || lowercaseEnvironmentName == 'production'
@@ -281,6 +285,7 @@ module storageProcessJob '../../modules/blob-event-processor/container-app-job.b
     containerRegistryServer: containerRegistry.outputs.endpoint
     imageTag: storageProcessJobImageTag
     matchApiBaseAddress: 'https://matching-api.internal.${containerAppEnvironment.outputs.defaultDomain}'
+    storageProcessJobConfiguration: storageProcessJobConfiguration
     tags: tags
     includeRoleAssignments: includeRoleAssignments
   }

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -77,8 +77,8 @@ param tagEnvironmentName string = ''
 param additionalTags object = {}
 
 @secure()
-@description('Optional runtime configuration values for the storage process job.')
-param storageProcessJobConfiguration object = {}
+@description('Runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object
 
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'blob-event-processor'

--- a/infra/stacks/blob-event-processor/subscription.bicep
+++ b/infra/stacks/blob-event-processor/subscription.bicep
@@ -76,6 +76,10 @@ param tagEnvironmentName string = ''
 @description('Optional additional tags to apply to deployed resources.')
 param additionalTags object = {}
 
+@secure()
+@description('Optional runtime configuration values for the storage process job.')
+param storageProcessJobConfiguration object = {}
+
 var lowercaseEnvironmentName = toLower(environmentName)
 var stackName = 'blob-event-processor'
 var stackResourceGroupName = '${environmentPrefix}-${lowercaseEnvironmentName}-${stackName}'
@@ -116,6 +120,7 @@ module stackDeployment 'main.bicep' = {
     existingStorageAccountName: existingStorageAccountName
     tagEnvironmentName: tagEnvironmentName
     additionalTags: additionalTags
+    storageProcessJobConfiguration: storageProcessJobConfiguration
   }
   dependsOn: [
     stackResourceGroup

--- a/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IMatchingApiClient.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IMatchingApiClient.cs
@@ -8,4 +8,9 @@ public interface IMatchingApiClient
         SearchSpecification payload,
         CancellationToken cancellationToken
     );
+
+    Task<ReconciliationResponse?> ReconcilePersonAsync(
+        ReconciliationRequest payload,
+        CancellationToken cancellationToken
+    );
 }

--- a/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IReconciliationDataParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IReconciliationDataParser.cs
@@ -1,0 +1,8 @@
+namespace SUI.Client.Core.Application.Interfaces;
+
+public interface IReconciliationDataParser<TSource>
+{
+    ReconciliationSourceData Parse(TSource record);
+}
+
+public sealed record ReconciliationSourceData(string? NhsNumber, string? AddressHistory);

--- a/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IReconciliationDataParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/Interfaces/IReconciliationDataParser.cs
@@ -1,6 +1,6 @@
 namespace SUI.Client.Core.Application.Interfaces;
 
-public interface IReconciliationDataParser<TSource>
+public interface IReconciliationDataParser<in TSource>
 {
     ReconciliationSourceData Parse(TSource record);
 }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/MatchPeople/ProcessedMatchRecord.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/MatchPeople/ProcessedMatchRecord.cs
@@ -1,4 +1,5 @@
 using Shared.Models;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
 namespace SUI.Client.Core.Application.UseCases.MatchPeople;
 
@@ -9,6 +10,10 @@ public class ProcessedMatchRecord<TSource>
 
     // The result from the API
     public PersonMatchResponse? ApiResult { get; set; }
+    public ReconciliationResponse? ReconciliationResult { get; set; }
+    public DateOnly? SourceBirthDate { get; set; }
+    public string? SourceNhsNumber { get; set; }
+    public AddressComparisonResults? AddressComparisonResults { get; set; }
 
     // Metadata for the edges to know how to handle this row
     public bool IsSuccess { get; set; }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressComparisonOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressComparisonOrchestrator.cs
@@ -2,9 +2,11 @@ using Shared.Models;
 
 namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
-public static class AddressComparisonOrchestrator
+public sealed class AddressComparisonOrchestrator(
+    ISourceAddressHistoryParser sourceAddressHistoryParser
+)
 {
-    public static AddressComparisonResults GetAddressComparisonResult(
+    public AddressComparisonResults GetAddressComparisonResult(
         ReconciliationRequest request,
         ReconciliationResponse? response,
         string? addressHistoryCsv
@@ -18,7 +20,7 @@ public static class AddressComparisonOrchestrator
         }
 
         var pdsAddressHistory = AddressParser.FromNhsPerson(response.Person);
-        var queryingAddressHistory = AddressParser.ParseHistory(
+        var queryingAddressHistory = sourceAddressHistoryParser.Parse(
             addressHistoryCsv,
             request.AddressPostalCode
         );

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressDelimiterParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressDelimiterParser.cs
@@ -6,8 +6,6 @@ namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
 public static class AddressParser
 {
-    private const string MultipleAddressDelimiter = "|";
-
     /// <summary>
     /// Parses an address record delimited by "~" into its components, specifically extracting the house number and postcode.
     /// </summary>
@@ -39,81 +37,6 @@ public static class AddressParser
     }
 
     /// <summary>
-    /// Parses a history of address records delimited by "|" into an AddressHistory object.
-    /// Each record in the history is delimited by "~".
-    /// <para>The order of the history string is preserved</para>
-    /// </summary>
-    public static AddressHistory ParseHistory(string? historyString, string? primaryPostcode)
-    {
-        if (string.IsNullOrWhiteSpace(historyString) || string.IsNullOrWhiteSpace(primaryPostcode))
-        {
-            return new AddressHistory([]);
-        }
-
-        if (!historyString.Contains('~'))
-        {
-            return ParseNewestFirstCommaSeparatedHistory(historyString, primaryPostcode);
-        }
-
-        var parts = historyString.Split(
-            MultipleAddressDelimiter,
-            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
-        );
-        var addresses = ParseToAddressMinimalList(parts);
-
-        // Primary address is identified by matching the provided primary postcode to the postcode of the parsed addresses and selecting the latest.
-        // Addresses 'should' be in chronological order, but we will select the last match as a fallback in case of duplicates or ordering issues.
-        var normalizedPostcode = NormalizePostcode(primaryPostcode);
-        AddressMinimal? primaryAddress = addresses.LastOrDefault(a =>
-            a.Postcode.Equals(normalizedPostcode, StringComparison.OrdinalIgnoreCase)
-        );
-
-        return new AddressHistory(addresses, primaryAddress);
-    }
-
-    private static AddressHistory ParseNewestFirstCommaSeparatedHistory(
-        string historyString,
-        string primaryPostcode
-    )
-    {
-        var addresses = historyString
-            .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
-            .Select(ParseCommaSeparatedAddress)
-            .OfType<AddressMinimal>()
-            .ToList();
-        var normalizedPostcode = NormalizePostcode(primaryPostcode);
-        var primaryAddress = addresses.FirstOrDefault(address =>
-            address.Postcode.Equals(normalizedPostcode, StringComparison.OrdinalIgnoreCase)
-        );
-
-        return new AddressHistory(addresses, primaryAddress);
-    }
-
-    private static AddressMinimal? ParseCommaSeparatedAddress(string value)
-    {
-        var parts = value.Split(
-            ',',
-            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
-        );
-        if (parts.Length < 2)
-        {
-            return null;
-        }
-
-        var postcode = NormalizePostcode(parts[^1]);
-        if (string.IsNullOrWhiteSpace(postcode))
-        {
-            return null;
-        }
-
-        return new AddressMinimal(
-            ExtractHouseNumber(parts[0]),
-            parts.Length > 2 ? ExtractHouseNumber(parts[1]) : null,
-            postcode
-        );
-    }
-
-    /// <summary>
     /// Creates an AddressHistory from an NhsPerson's address history.
     /// </summary>
     public static AddressHistory FromNhsPerson(NhsPerson person)
@@ -142,7 +65,7 @@ public static class AddressParser
         return parts.Select(ParseRecord).OfType<AddressMinimal>().ToList();
     }
 
-    private static string? ExtractHouseNumber(string addressLine)
+    internal static string? ExtractHouseNumber(string addressLine)
     {
         if (string.IsNullOrWhiteSpace(addressLine))
             return null;
@@ -172,7 +95,7 @@ public static class AddressParser
         return true;
     }
 
-    private static string NormalizePostcode(string postcode)
+    internal static string NormalizePostcode(string postcode)
     {
         return new string(postcode.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
     }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressDelimiterParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/AddressDelimiterParser.cs
@@ -50,6 +50,11 @@ public static class AddressParser
             return new AddressHistory([]);
         }
 
+        if (!historyString.Contains('~'))
+        {
+            return ParseNewestFirstCommaSeparatedHistory(historyString, primaryPostcode);
+        }
+
         var parts = historyString.Split(
             MultipleAddressDelimiter,
             StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
@@ -64,6 +69,48 @@ public static class AddressParser
         );
 
         return new AddressHistory(addresses, primaryAddress);
+    }
+
+    private static AddressHistory ParseNewestFirstCommaSeparatedHistory(
+        string historyString,
+        string primaryPostcode
+    )
+    {
+        var addresses = historyString
+            .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(ParseCommaSeparatedAddress)
+            .OfType<AddressMinimal>()
+            .ToList();
+        var normalizedPostcode = NormalizePostcode(primaryPostcode);
+        var primaryAddress = addresses.FirstOrDefault(address =>
+            address.Postcode.Equals(normalizedPostcode, StringComparison.OrdinalIgnoreCase)
+        );
+
+        return new AddressHistory(addresses, primaryAddress);
+    }
+
+    private static AddressMinimal? ParseCommaSeparatedAddress(string value)
+    {
+        var parts = value.Split(
+            ',',
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
+        );
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        var postcode = NormalizePostcode(parts[^1]);
+        if (string.IsNullOrWhiteSpace(postcode))
+        {
+            return null;
+        }
+
+        return new AddressMinimal(
+            ExtractHouseNumber(parts[0]),
+            parts.Length > 2 ? ExtractHouseNumber(parts[1]) : null,
+            postcode
+        );
     }
 
     /// <summary>

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ISourceAddressHistoryParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ISourceAddressHistoryParser.cs
@@ -1,0 +1,8 @@
+using SUI.Client.Core.Domain.Models;
+
+namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
+
+public interface ISourceAddressHistoryParser
+{
+    AddressHistory Parse(string? historyString, string? primaryPostcode);
+}

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -11,6 +11,7 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
     IMatchingApiClient matchingApiClient,
     IPersonSpecParser<TSource> personSpecParser,
     IReconciliationDataParser<TSource> reconciliationDataParser,
+    AddressComparisonOrchestrator addressComparisonOrchestrator,
     IOptions<PersonMatchingOptions> options
 ) : IMatchPersonRecordOrchestrator<TSource>
 {
@@ -55,12 +56,11 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
                         Result = response.MatchingResult,
                         SearchId = response.SearchId,
                     };
-                var addressComparison =
-                    AddressComparisonOrchestrator.GetAddressComparisonResult(
-                        payload,
-                        response,
-                        sourceData.AddressHistory
-                    );
+                var addressComparison = addressComparisonOrchestrator.GetAddressComparisonResult(
+                    payload,
+                    response,
+                    sourceData.AddressHistory
+                );
 
                 processedBatch.Add(
                     new ProcessedMatchRecord<TSource>

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -2,13 +2,15 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Shared.Models;
 using SUI.Client.Core.Application.Interfaces;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
 
-namespace SUI.Client.Core.Application.UseCases.MatchPeople;
+namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
-public sealed class MatchPersonRecordOrchestrator<TSource>(
-    ILogger<MatchPersonRecordOrchestrator<TSource>> logger,
+public sealed class ReconcilePersonRecordOrchestrator<TSource>(
+    ILogger<ReconcilePersonRecordOrchestrator<TSource>> logger,
     IMatchingApiClient matchingApiClient,
     IPersonSpecParser<TSource> personSpecParser,
+    IReconciliationDataParser<TSource> reconciliationDataParser,
     IOptions<PersonMatchingOptions> options
 ) : IMatchPersonRecordOrchestrator<TSource>
 {
@@ -18,16 +20,17 @@ public sealed class MatchPersonRecordOrchestrator<TSource>(
         CancellationToken cancellationToken
     )
     {
-        var stats = new MatchingProcessStats();
         var processedBatch = new List<ProcessedMatchRecord<TSource>>();
+
         foreach (var record in content)
         {
             try
             {
                 var person = personSpecParser.Parse(record);
-
-                var payload = new SearchSpecification
+                var sourceData = reconciliationDataParser.Parse(record);
+                var payload = new ReconciliationRequest
                 {
+                    NhsNumber = sourceData.NhsNumber,
                     Given = person.Given,
                     Family = person.Family,
                     BirthDate = person.BirthDate,
@@ -41,15 +44,35 @@ public sealed class MatchPersonRecordOrchestrator<TSource>(
                     StrategyVersion = options.Value.StrategyVersion,
                 };
 
-                var response = await matchingApiClient.MatchPersonAsync(payload, cancellationToken);
-                stats.RecordStats(response);
+                var response = await matchingApiClient.ReconcilePersonAsync(
+                    payload,
+                    cancellationToken
+                );
+                var matchingResponse = response is null
+                    ? null
+                    : new PersonMatchResponse
+                    {
+                        Result = response.MatchingResult,
+                        SearchId = response.SearchId,
+                    };
+                var addressComparison =
+                    AddressComparisonOrchestrator.GetAddressComparisonResult(
+                        payload,
+                        response,
+                        sourceData.AddressHistory
+                    );
+
                 processedBatch.Add(
                     new ProcessedMatchRecord<TSource>
                     {
                         OriginalData = record,
-                        ApiResult = response,
+                        ApiResult = matchingResponse,
+                        ReconciliationResult = response,
                         SourceBirthDate = person.BirthDate,
-                        IsSuccess = response?.Result is not null,
+                        SourceNhsNumber = sourceData.NhsNumber,
+                        AddressComparisonResults = addressComparison,
+                        IsSuccess =
+                            response is not null && response.Status != ReconciliationStatus.Error,
                         ErrorMessage = string.Empty,
                     }
                 );
@@ -60,12 +83,10 @@ public sealed class MatchPersonRecordOrchestrator<TSource>(
             }
             catch (Exception ex)
             {
-                stats.RecordError();
                 processedBatch.Add(
                     new ProcessedMatchRecord<TSource>
                     {
                         OriginalData = record,
-                        ApiResult = null,
                         IsSuccess = false,
                         ErrorMessage = ex.Message,
                     }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/SemicolonCommaNewestFirstAddressHistoryParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/SemicolonCommaNewestFirstAddressHistoryParser.cs
@@ -1,0 +1,50 @@
+using SUI.Client.Core.Domain.Models;
+
+namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
+
+public sealed class SemicolonCommaNewestFirstAddressHistoryParser : ISourceAddressHistoryParser
+{
+    public AddressHistory Parse(string? historyString, string? primaryPostcode)
+    {
+        if (string.IsNullOrWhiteSpace(historyString) || string.IsNullOrWhiteSpace(primaryPostcode))
+        {
+            return new AddressHistory([]);
+        }
+
+        var addresses = historyString
+            .Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries)
+            .Select(ParseCommaSeparatedAddress)
+            .OfType<AddressMinimal>()
+            .ToList();
+        var normalizedPostcode = AddressParser.NormalizePostcode(primaryPostcode);
+        var primaryAddress = addresses.FirstOrDefault(address =>
+            address.Postcode.Equals(normalizedPostcode, StringComparison.OrdinalIgnoreCase)
+        );
+
+        return new AddressHistory(addresses, primaryAddress);
+    }
+
+    private static AddressMinimal? ParseCommaSeparatedAddress(string value)
+    {
+        var parts = value.Split(
+            ',',
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
+        );
+        if (parts.Length < 2)
+        {
+            return null;
+        }
+
+        var postcode = AddressParser.NormalizePostcode(parts[^1]);
+        if (string.IsNullOrWhiteSpace(postcode))
+        {
+            return null;
+        }
+
+        return new AddressMinimal(
+            AddressParser.ExtractHouseNumber(parts[0]),
+            parts.Length > 2 ? AddressParser.ExtractHouseNumber(parts[1]) : null,
+            postcode
+        );
+    }
+}

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/SourceAddressHistoryFormat.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/SourceAddressHistoryFormat.cs
@@ -1,0 +1,7 @@
+namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
+
+public enum SourceAddressHistoryFormat
+{
+    TildePipeChronological,
+    SemicolonCommaNewestFirst,
+}

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/TildePipeChronologicalAddressHistoryParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/TildePipeChronologicalAddressHistoryParser.cs
@@ -1,0 +1,31 @@
+using SUI.Client.Core.Domain.Models;
+
+namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
+
+public sealed class TildePipeChronologicalAddressHistoryParser : ISourceAddressHistoryParser
+{
+    private const string MultipleAddressDelimiter = "|";
+
+    public AddressHistory Parse(string? historyString, string? primaryPostcode)
+    {
+        if (string.IsNullOrWhiteSpace(historyString) || string.IsNullOrWhiteSpace(primaryPostcode))
+        {
+            return new AddressHistory([]);
+        }
+
+        var parts = historyString.Split(
+            MultipleAddressDelimiter,
+            StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries
+        );
+        var addresses = parts.Select(AddressParser.ParseRecord).OfType<AddressMinimal>().ToList();
+
+        // Primary address is identified by matching the provided primary postcode to the postcode of the parsed addresses and selecting the latest.
+        // Addresses 'should' be in chronological order, but we will select the last match as a fallback in case of duplicates or ordering issues.
+        var normalizedPostcode = AddressParser.NormalizePostcode(primaryPostcode);
+        AddressMinimal? primaryAddress = addresses.LastOrDefault(a =>
+            a.Postcode.Equals(normalizedPostcode, StringComparison.OrdinalIgnoreCase)
+        );
+
+        return new AddressHistory(addresses, primaryAddress);
+    }
+}

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchDataOptions.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchDataOptions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.Extensions.Options;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
 namespace SUI.Client.Core.Infrastructure.CsvParsers;
 
@@ -12,6 +13,9 @@ public record CsvMatchDataOptions
 
     [ValidateObjectMembers]
     public required Headers ColumnMappings { get; init; }
+
+    public SourceAddressHistoryFormat AddressHistoryFormat { get; init; } =
+        SourceAddressHistoryFormat.TildePipeChronological;
 
     public record Headers
     {

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchDataOptions.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchDataOptions.cs
@@ -39,5 +39,6 @@ public record CsvMatchDataOptions
         [Required]
         public string Phone { get; init; } = "Phone";
         public string? NhsNumber { get; init; }
+        public string? Address { get; init; }
     }
 }

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchingHeadersProvider.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvMatchingHeadersProvider.cs
@@ -24,6 +24,16 @@ public sealed class CsvMatchingHeadersProvider(IOptions<CsvMatchDataOptions> csv
     {
         var columnMappings = csvMatchDataOptions.Value.ColumnMappings;
 
-        return [columnMappings.Email, columnMappings.Gender, columnMappings.Phone];
+        return
+        [
+            columnMappings.Email,
+            columnMappings.Gender,
+            columnMappings.Phone,
+            .. Optional(columnMappings.NhsNumber),
+            .. Optional(columnMappings.Address),
+        ];
     }
+
+    private static IEnumerable<string> Optional(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? [] : [value];
 }

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvPersonSpecParser.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/CsvParsers/CsvPersonSpecParser.cs
@@ -8,7 +8,8 @@ using SUI.Client.Core.Infrastructure.FileSystem;
 namespace SUI.Client.Core.Infrastructure.CsvParsers;
 
 public class CsvPersonSpecParser(IOptions<CsvMatchDataOptions> csvMatchDataOptions)
-    : IPersonSpecParser<CsvRecordDto>
+    : IPersonSpecParser<CsvRecordDto>,
+        IReconciliationDataParser<CsvRecordDto>
 {
     public PersonSpecification Parse(CsvRecordDto csvRecord)
     {
@@ -39,6 +40,17 @@ public class CsvPersonSpecParser(IOptions<CsvMatchDataOptions> csvMatchDataOptio
         };
     }
 
+    ReconciliationSourceData IReconciliationDataParser<CsvRecordDto>.Parse(
+        CsvRecordDto csvRecord
+    )
+    {
+        var mappings = csvMatchDataOptions.Value.ColumnMappings;
+        return new ReconciliationSourceData(
+            GetMappedValue(csvRecord.Record, mappings.NhsNumber),
+            GetMappedValue(csvRecord.Record, mappings.Address)
+        );
+    }
+
     /// <summary>
     /// Find and extract any properties from the CSV record that are not part of the standard mapped fields.
     /// </summary>
@@ -64,4 +76,12 @@ public class CsvPersonSpecParser(IOptions<CsvMatchDataOptions> csvMatchDataOptio
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         return mappedColumns.Contains(columnName);
     }
+
+    private static string? GetMappedValue(
+        Dictionary<string, string> record,
+        string? mappedColumn
+    ) =>
+        string.IsNullOrWhiteSpace(mappedColumn)
+            ? null
+            : record.GetFirstValueOrDefault([mappedColumn]);
 }

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/FileSystem/ReconciliationCsvFileProcessor.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/FileSystem/ReconciliationCsvFileProcessor.cs
@@ -17,7 +17,8 @@ public class ReconciliationCsvFileProcessor(
     ILogger<ReconciliationCsvFileProcessor> logger,
     CsvMappingConfig mapping,
     IMatchingService matching,
-    IOptions<CsvWatcherConfig> watcherConfig
+    IOptions<CsvWatcherConfig> watcherConfig,
+    AddressComparisonOrchestrator addressComparisonOrchestrator
 ) : ICsvFileProcessor
 {
     private readonly ReconciliationProcessStats _stats = new();
@@ -104,7 +105,7 @@ public class ReconciliationCsvFileProcessor(
 
         var response = await matching.ReconcilePersonAsync(payload);
 
-        var addressComparisonResult = AddressComparisonOrchestrator.GetAddressComparisonResult(
+        var addressComparisonResult = addressComparisonOrchestrator.GetAddressComparisonResult(
             payload,
             response,
             record.GetFirstValueOrDefault(

--- a/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
+++ b/src/SUI.Client/SUI.Client.Core/Infrastructure/Http/MatchingApiClient.cs
@@ -10,6 +10,7 @@ namespace SUI.Client.Core.Infrastructure.Http;
 public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClient
 {
     private const string MatchPersonPath = "api/v1/matchperson";
+    private const string ReconciliationPath = "api/v1/reconciliation";
 
     private static readonly JsonSerializerOptions JsonSerializerOptions = new()
     {
@@ -59,6 +60,59 @@ public sealed class MatchingApiClient(HttpClient httpClient) : IMatchingApiClien
         {
             throw new HttpRequestException(
                 $"Matching API request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase})."
+            );
+        }
+
+        return null;
+    }
+
+    public async Task<ReconciliationResponse?> ReconcilePersonAsync(
+        ReconciliationRequest payload,
+        CancellationToken cancellationToken
+    )
+    {
+        var response = await httpClient.PostAsJsonAsync(
+            BuildRequestUri(ReconciliationPath),
+            payload,
+            cancellationToken
+        );
+
+        var reason = await response.Content.ReadAsStringAsync(cancellationToken);
+        if (reason.Contains(SharedConstants.SearchStrategy.VersionErrorMessagePrefix))
+        {
+            throw new NotSupportedException(reason);
+        }
+
+        ReconciliationResponse? dto = null;
+        if (!string.IsNullOrWhiteSpace(reason))
+        {
+            try
+            {
+                dto = JsonSerializer.Deserialize<ReconciliationResponse>(
+                    reason,
+                    JsonSerializerOptions
+                );
+            }
+            catch (JsonException)
+            {
+                dto = null;
+            }
+        }
+
+        if (response.IsSuccessStatusCode && dto is not null)
+        {
+            return dto;
+        }
+
+        if (dto?.Status == ReconciliationStatus.Error)
+        {
+            return dto;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException(
+                $"Reconciliation API request failed with status code {(int)response.StatusCode} ({response.ReasonPhrase})."
             );
         }
 

--- a/src/SUI.Client/SUI.Client.Core/ServiceCollectionExtensions.cs
+++ b/src/SUI.Client/SUI.Client.Core/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 using Shared.Logging;
 using SUI.Client.Core.Application.Interfaces;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 using SUI.Client.Core.Infrastructure.FileSystem;
 using SUI.Client.Core.Infrastructure.Http;
 
@@ -38,6 +39,8 @@ public static class ServiceCollectionExtensions
             configuration.GetSection("CsvMapping").Get<CsvMappingConfig>()
             ?? new CsvMappingConfig();
         services.AddSingleton(mapping);
+        services.AddSingleton<ISourceAddressHistoryParser, TildePipeChronologicalAddressHistoryParser>();
+        services.AddSingleton<AddressComparisonOrchestrator>();
         if (enableReconciliationMode)
         {
             services.AddSingleton<ICsvFileProcessor, ReconciliationCsvFileProcessor>();

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/MatchResultsService.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/MatchResultsService.cs
@@ -5,6 +5,7 @@ using CsvHelper.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Shared.Models;
+using Shared.Util;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
@@ -20,6 +21,8 @@ public sealed class MatchResultsService(
 ) : IMatchResultsService
 {
     private const string CsvContentType = "text/csv";
+    private const string Yes = "Yes";
+    private const string No = "No";
 
     public async Task ExportSuccessResultsAsync(
         MatchResultsBlobNames blobNames,
@@ -82,7 +85,13 @@ public sealed class MatchResultsService(
             return;
         }
 
-        var csvContent = BuildFullResultsCsv(matchedResults);
+        var csvContent = BuildFullResultsCsv(
+            matchedResults,
+            storageOptions.Value.ProcessingMode.Equals(
+                ProcessingModes.Reconciliation,
+                StringComparison.OrdinalIgnoreCase
+            )
+        );
 
         await blobStorageClient.UploadBlobAsync(
             storageOptions.Value.ProcessedContainerName,
@@ -164,13 +173,24 @@ public sealed class MatchResultsService(
     }
 
     private static string BuildFullResultsCsv(
-        IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults
+        IReadOnlyCollection<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
+        bool includeReconciliationFields
     )
     {
         const string fullStatusHeader = "SUI_Status";
         const string fullScoreHeader = "SUI_Score";
         const string fullNhsNumberHeader = "SUI_NHSNo";
         const string fullSearchIdHeader = "SUI_SearchId";
+        const string ageGroupHeader = "SUI_AgeGroup";
+        const string primaryAddressSameHeader = "SUI_PrimaryAddressSame";
+        const string addressHistoriesIntersectHeader = "SUI_AddressHistoriesIntersect";
+        const string primarySourceAddressInPdsHistoryHeader =
+            "SUI_PrimarySourceAddressInPDSHistory";
+        const string primaryPdsAddressInSourceHistoryHeader =
+            "SUI_PrimaryPDSAddressInSourceHistory";
+        const string sourceNhsNumberPresentHeader = "SUI_SourceNhsNumberPresent";
+        const string sourceNhsNumberEqualsMatchedHeader =
+            "SUI_SourceNhsNumberEqualsMatchedNhsNumber";
 
         var originalHeaders =
             matchedResults.FirstOrDefault()?.OriginalData.Record.Keys.ToList() ?? [];
@@ -191,6 +211,16 @@ public sealed class MatchResultsService(
         csvWriter.WriteField(fullScoreHeader);
         csvWriter.WriteField(fullNhsNumberHeader);
         csvWriter.WriteField(fullSearchIdHeader);
+        if (includeReconciliationFields)
+        {
+            csvWriter.WriteField(ageGroupHeader);
+            csvWriter.WriteField(primaryAddressSameHeader);
+            csvWriter.WriteField(addressHistoriesIntersectHeader);
+            csvWriter.WriteField(primarySourceAddressInPdsHistoryHeader);
+            csvWriter.WriteField(primaryPdsAddressInSourceHistoryHeader);
+            csvWriter.WriteField(sourceNhsNumberPresentHeader);
+            csvWriter.WriteField(sourceNhsNumberEqualsMatchedHeader);
+        }
         csvWriter.NextRecord();
 
         foreach (var matchedResult in matchedResults)
@@ -208,6 +238,45 @@ public sealed class MatchResultsService(
             );
             csvWriter.WriteField(matchedResult.ApiResult?.Result?.NhsNumber ?? "-");
             csvWriter.WriteField(matchedResult.ApiResult?.SearchId ?? "-");
+            if (includeReconciliationFields)
+            {
+                var addressComparison = matchedResult.AddressComparisonResults;
+                csvWriter.WriteField(
+                    matchedResult.SourceBirthDate.HasValue
+                        ? PersonSpecificationUtils.GetAgeGroup(
+                            matchedResult.SourceBirthDate.Value
+                        )
+                        : "Unknown"
+                );
+                csvWriter.WriteField(
+                    addressComparison?.PrimaryAddressSame.GetResultMessage() ?? "NoComparison"
+                );
+                csvWriter.WriteField(
+                    addressComparison?.AddressHistoriesIntersect.GetResultMessage()
+                        ?? "NoComparison"
+                );
+                csvWriter.WriteField(
+                    addressComparison?.PrimaryCMSAddressInPDSHistory.GetResultMessage()
+                        ?? "NoComparison"
+                );
+                csvWriter.WriteField(
+                    addressComparison?.PrimaryPDSAddressInCMSHistory.GetResultMessage()
+                        ?? "NoComparison"
+                );
+                csvWriter.WriteField(
+                    string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber) ? No : Yes
+                );
+                csvWriter.WriteField(
+                    !string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber)
+                    && string.Equals(
+                        matchedResult.SourceNhsNumber,
+                        matchedResult.ApiResult?.Result?.NhsNumber,
+                        StringComparison.Ordinal
+                    )
+                        ? Yes
+                        : No
+                );
+            }
             csvWriter.NextRecord();
         }
 
@@ -216,6 +285,11 @@ public sealed class MatchResultsService(
 
     private static string MapStatus(ProcessedMatchRecord<CsvRecordDto> matchedResult)
     {
+        if (matchedResult.ReconciliationResult is not null)
+        {
+            return matchedResult.ReconciliationResult.Status.ToString();
+        }
+
         if (matchedResult.ApiResult?.Result is not null)
         {
             return matchedResult.ApiResult.Result.MatchStatus.ToString();

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Application/MatchResultsService.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Application/MatchResultsService.cs
@@ -23,6 +23,7 @@ public sealed class MatchResultsService(
     private const string CsvContentType = "text/csv";
     private const string Yes = "Yes";
     private const string No = "No";
+    private const string NoComparison = "NoComparison";
 
     public async Task ExportSuccessResultsAsync(
         MatchResultsBlobNames blobNames,
@@ -202,85 +203,123 @@ public sealed class MatchResultsService(
             new CsvConfiguration(CultureInfo.InvariantCulture) { NewLine = Environment.NewLine }
         );
 
-        foreach (var header in originalHeaders)
-        {
-            csvWriter.WriteField(header);
-        }
-
-        csvWriter.WriteField(fullStatusHeader);
-        csvWriter.WriteField(fullScoreHeader);
-        csvWriter.WriteField(fullNhsNumberHeader);
-        csvWriter.WriteField(fullSearchIdHeader);
-        if (includeReconciliationFields)
-        {
-            csvWriter.WriteField(ageGroupHeader);
-            csvWriter.WriteField(primaryAddressSameHeader);
-            csvWriter.WriteField(addressHistoriesIntersectHeader);
-            csvWriter.WriteField(primarySourceAddressInPdsHistoryHeader);
-            csvWriter.WriteField(primaryPdsAddressInSourceHistoryHeader);
-            csvWriter.WriteField(sourceNhsNumberPresentHeader);
-            csvWriter.WriteField(sourceNhsNumberEqualsMatchedHeader);
-        }
+        WriteHeaders(
+            csvWriter,
+            originalHeaders,
+            includeReconciliationFields,
+            [
+                fullStatusHeader,
+                fullScoreHeader,
+                fullNhsNumberHeader,
+                fullSearchIdHeader,
+            ],
+            [
+                ageGroupHeader,
+                primaryAddressSameHeader,
+                addressHistoriesIntersectHeader,
+                primarySourceAddressInPdsHistoryHeader,
+                primaryPdsAddressInSourceHistoryHeader,
+                sourceNhsNumberPresentHeader,
+                sourceNhsNumberEqualsMatchedHeader,
+            ]
+        );
         csvWriter.NextRecord();
 
         foreach (var matchedResult in matchedResults)
         {
-            foreach (var header in originalHeaders)
-            {
-                matchedResult.OriginalData.Record.TryGetValue(header, out var value);
-                csvWriter.WriteField(value);
-            }
+            WriteFullResult(csvWriter, originalHeaders, matchedResult);
 
-            csvWriter.WriteField(MapStatus(matchedResult));
-            csvWriter.WriteField(
-                matchedResult.ApiResult?.Result?.Score?.ToString(CultureInfo.InvariantCulture)
-                    ?? "-"
-            );
-            csvWriter.WriteField(matchedResult.ApiResult?.Result?.NhsNumber ?? "-");
-            csvWriter.WriteField(matchedResult.ApiResult?.SearchId ?? "-");
             if (includeReconciliationFields)
             {
-                var addressComparison = matchedResult.AddressComparisonResults;
-                csvWriter.WriteField(
-                    matchedResult.SourceBirthDate.HasValue
-                        ? PersonSpecificationUtils.GetAgeGroup(
-                            matchedResult.SourceBirthDate.Value
-                        )
-                        : "Unknown"
-                );
-                csvWriter.WriteField(
-                    addressComparison?.PrimaryAddressSame.GetResultMessage() ?? "NoComparison"
-                );
-                csvWriter.WriteField(
-                    addressComparison?.AddressHistoriesIntersect.GetResultMessage()
-                        ?? "NoComparison"
-                );
-                csvWriter.WriteField(
-                    addressComparison?.PrimaryCMSAddressInPDSHistory.GetResultMessage()
-                        ?? "NoComparison"
-                );
-                csvWriter.WriteField(
-                    addressComparison?.PrimaryPDSAddressInCMSHistory.GetResultMessage()
-                        ?? "NoComparison"
-                );
-                csvWriter.WriteField(
-                    string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber) ? No : Yes
-                );
-                csvWriter.WriteField(
-                    !string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber)
-                    && string.Equals(
-                        matchedResult.SourceNhsNumber,
-                        matchedResult.ApiResult?.Result?.NhsNumber,
-                        StringComparison.Ordinal
-                    )
-                        ? Yes
-                        : No
-                );
+                WriteReconciliationFields(csvWriter, matchedResult);
             }
+
             csvWriter.NextRecord();
         }
 
         return builder.ToString();
+    }
+
+    private static void WriteHeaders(
+        CsvWriter csvWriter,
+        IReadOnlyCollection<string> originalHeaders,
+        bool includeReconciliationFields,
+        IReadOnlyCollection<string> resultHeaders,
+        IReadOnlyCollection<string> reconciliationHeaders
+    )
+    {
+        foreach (var header in originalHeaders.Concat(resultHeaders))
+        {
+            csvWriter.WriteField(header);
+        }
+
+        if (!includeReconciliationFields)
+        {
+            return;
+        }
+
+        foreach (var header in reconciliationHeaders)
+        {
+            csvWriter.WriteField(header);
+        }
+    }
+
+    private static void WriteFullResult(
+        CsvWriter csvWriter,
+        IReadOnlyCollection<string> originalHeaders,
+        ProcessedMatchRecord<CsvRecordDto> matchedResult
+    )
+    {
+        foreach (var header in originalHeaders)
+        {
+            matchedResult.OriginalData.Record.TryGetValue(header, out var value);
+            csvWriter.WriteField(value);
+        }
+
+        csvWriter.WriteField(MapStatus(matchedResult));
+        csvWriter.WriteField(
+            matchedResult.ApiResult?.Result?.Score?.ToString(CultureInfo.InvariantCulture) ?? "-"
+        );
+        csvWriter.WriteField(matchedResult.ApiResult?.Result?.NhsNumber ?? "-");
+        csvWriter.WriteField(matchedResult.ApiResult?.SearchId ?? "-");
+    }
+
+    private static void WriteReconciliationFields(
+        CsvWriter csvWriter,
+        ProcessedMatchRecord<CsvRecordDto> matchedResult
+    )
+    {
+        var addressComparison = matchedResult.AddressComparisonResults;
+        csvWriter.WriteField(
+            matchedResult.SourceBirthDate.HasValue
+                ? PersonSpecificationUtils.GetAgeGroup(matchedResult.SourceBirthDate.Value)
+                : "Unknown"
+        );
+        csvWriter.WriteField(
+            addressComparison?.PrimaryAddressSame.GetResultMessage() ?? NoComparison
+        );
+        csvWriter.WriteField(
+            addressComparison?.AddressHistoriesIntersect.GetResultMessage() ?? NoComparison
+        );
+        csvWriter.WriteField(
+            addressComparison?.PrimaryCMSAddressInPDSHistory.GetResultMessage() ?? NoComparison
+        );
+        csvWriter.WriteField(
+            addressComparison?.PrimaryPDSAddressInCMSHistory.GetResultMessage() ?? NoComparison
+        );
+        csvWriter.WriteField(
+            string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber) ? No : Yes
+        );
+        csvWriter.WriteField(
+            !string.IsNullOrWhiteSpace(matchedResult.SourceNhsNumber)
+            && string.Equals(
+                matchedResult.SourceNhsNumber,
+                matchedResult.ApiResult?.Result?.NhsNumber,
+                StringComparison.Ordinal
+            )
+                ? Yes
+                : No
+        );
     }
 
     private static string MapStatus(ProcessedMatchRecord<CsvRecordDto> matchedResult)

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile
@@ -18,30 +18,10 @@ RUN dotnet publish src/SUI.Client/SUI.Client.StorageProcessJob/SUI.Client.Storag
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
-ARG CSV_DATE_FORMAT=yyyy-MM-dd
 ARG MATCH_API_BASE_ADDRESS
-ARG CSV_COLUMN_ID=Id
-ARG CSV_COLUMN_GIVEN=GivenName
-ARG CSV_COLUMN_FAMILY=FamilyName
-ARG CSV_COLUMN_BIRTH_DATE=DOB
-ARG CSV_COLUMN_EMAIL=EMAIL
-ARG CSV_COLUMN_POSTCODE=POSTCODE
-ARG CSV_COLUMN_GENDER=GENDER
-ARG CSV_COLUMN_PHONE=PHONE
-ARG CSV_COLUMN_NHS_NUMBER=NHS_NUMBER
 
 ENV DOTNET_ENVIRONMENT=Production \
-    StorageProcessJob__MatchApiBaseAddress=${MATCH_API_BASE_ADDRESS} \
-    CsvMatchData__DateFormat=${CSV_DATE_FORMAT} \
-    CsvMatchData__ColumnMappings__Id=${CSV_COLUMN_ID} \
-    CsvMatchData__ColumnMappings__Given=${CSV_COLUMN_GIVEN} \
-    CsvMatchData__ColumnMappings__Family=${CSV_COLUMN_FAMILY} \
-    CsvMatchData__ColumnMappings__BirthDate=${CSV_COLUMN_BIRTH_DATE} \
-    CsvMatchData__ColumnMappings__Email=${CSV_COLUMN_EMAIL} \
-    CsvMatchData__ColumnMappings__Postcode=${CSV_COLUMN_POSTCODE} \
-    CsvMatchData__ColumnMappings__Gender=${CSV_COLUMN_GENDER} \
-    CsvMatchData__ColumnMappings__Phone=${CSV_COLUMN_PHONE} \
-    CsvMatchData__ColumnMappings__NhsNumber=${CSV_COLUMN_NHS_NUMBER}
+    StorageProcessJob__MatchApiBaseAddress=${MATCH_API_BASE_ADDRESS}
 
 COPY --from=build /app/publish .
 USER app

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Options;
 using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
 using SUI.Client.Core.Infrastructure.Http;
 using SUI.Client.StorageProcessJob;
@@ -32,6 +33,18 @@ builder
             && options.MessageVisibilityRenewalIntervalMinutes
                 < options.MessageVisibilityTimeoutMinutes,
         "MaxDequeueCount must be positive, and the message visibility renewal interval must be positive and less than the visibility timeout."
+    )
+    .Validate(
+        options =>
+            options.ProcessingMode.Equals(
+                ProcessingModes.Matching,
+                StringComparison.OrdinalIgnoreCase
+            )
+            || options.ProcessingMode.Equals(
+                ProcessingModes.Reconciliation,
+                StringComparison.OrdinalIgnoreCase
+            ),
+        $"ProcessingMode must be {ProcessingModes.Matching} or {ProcessingModes.Reconciliation}."
     )
     .ValidateOnStart();
 
@@ -109,11 +122,27 @@ builder.Services.AddHttpClient<IMatchingApiClient, MatchingApiClient>(
     }
 );
 
-builder.Services.AddSingleton(
-    typeof(IMatchPersonRecordOrchestrator<>),
-    typeof(MatchPersonRecordOrchestrator<>)
+builder.Services.AddSingleton<MatchPersonRecordOrchestrator<CsvRecordDto>>();
+builder.Services.AddSingleton<ReconcilePersonRecordOrchestrator<CsvRecordDto>>();
+builder.Services.AddSingleton<IMatchPersonRecordOrchestrator<CsvRecordDto>>(serviceProvider =>
+{
+    var storageOptions = serviceProvider
+        .GetRequiredService<IOptions<StorageProcessJobOptions>>()
+        .Value;
+    return storageOptions.ProcessingMode.Equals(
+        ProcessingModes.Reconciliation,
+        StringComparison.OrdinalIgnoreCase
+    )
+        ? serviceProvider.GetRequiredService<ReconcilePersonRecordOrchestrator<CsvRecordDto>>()
+        : serviceProvider.GetRequiredService<MatchPersonRecordOrchestrator<CsvRecordDto>>();
+});
+builder.Services.AddSingleton<CsvPersonSpecParser>();
+builder.Services.AddSingleton<IPersonSpecParser<CsvRecordDto>>(serviceProvider =>
+    serviceProvider.GetRequiredService<CsvPersonSpecParser>()
 );
-builder.Services.AddSingleton<IPersonSpecParser<CsvRecordDto>, CsvPersonSpecParser>();
+builder.Services.AddSingleton<IReconciliationDataParser<CsvRecordDto>>(serviceProvider =>
+    serviceProvider.GetRequiredService<CsvPersonSpecParser>()
+);
 builder.Services.AddSingleton<ICsvHeadersProvider, CsvMatchingHeadersProvider>();
 
 builder.Services.AddHttpClient();

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -55,6 +55,10 @@ builder
     .Services.AddOptions<CsvMatchDataOptions>()
     .Bind(builder.Configuration.GetSection(CsvMatchDataOptions.SectionName))
     .ValidateDataAnnotations()
+    .Validate(
+        options => Enum.IsDefined(options.AddressHistoryFormat),
+        $"AddressHistoryFormat must be {SourceAddressHistoryFormat.TildePipeChronological} or {SourceAddressHistoryFormat.SemicolonCommaNewestFirst}."
+    )
     .ValidateOnStart();
 
 builder.Services.AddSingleton(TimeProvider.System);
@@ -101,6 +105,23 @@ builder.Services.AddSingleton<IStorageQueueMessageParser, EventGridMessageParser
 builder.Services.AddSingleton<IBlobFileOrchestrator, BlobFileOrchestrator>();
 builder.Services.AddSingleton<MatchResultsBlobNameBuilder>();
 builder.Services.AddSingleton<IMatchResultsService, MatchResultsService>();
+builder.Services.AddSingleton<TildePipeChronologicalAddressHistoryParser>();
+builder.Services.AddSingleton<SemicolonCommaNewestFirstAddressHistoryParser>();
+builder.Services.AddSingleton<ISourceAddressHistoryParser>(serviceProvider =>
+{
+    var options = serviceProvider.GetRequiredService<IOptions<CsvMatchDataOptions>>().Value;
+    return options.AddressHistoryFormat switch
+    {
+        SourceAddressHistoryFormat.TildePipeChronological =>
+            serviceProvider.GetRequiredService<TildePipeChronologicalAddressHistoryParser>(),
+        SourceAddressHistoryFormat.SemicolonCommaNewestFirst =>
+            serviceProvider.GetRequiredService<SemicolonCommaNewestFirstAddressHistoryParser>(),
+        _ => throw new InvalidOperationException(
+            $"Unsupported address history format '{options.AddressHistoryFormat}'."
+        ),
+    };
+});
+builder.Services.AddSingleton<AddressComparisonOrchestrator>();
 builder.Services.AddHttpClient<IMatchingApiClient, MatchingApiClient>(
     (serviceProvider, client) =>
     {

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
@@ -11,7 +11,7 @@ docker build \
   .
 ```
 
-The matching API base address can be baked into the image for local use. CSV mappings and processing mode must be provided at runtime so deployment-specific schemas are not stored in the image or repository.
+The Dockerfile only accepts the matching API base address as a build argument. CSV mappings and processing mode must be provided at runtime so deployment-specific schemas are not stored in the image or repository.
 
 ```bash
 docker build \
@@ -21,7 +21,7 @@ docker build \
   .
 ```
 
-`MATCH_API_BASE_ADDRESS` has no Dockerfile default. Supply it as a build arg when baking it into the image, or provide `StorageProcessJob__MatchApiBaseAddress` as a runtime environment variable.
+`MATCH_API_BASE_ADDRESS` has no Dockerfile default. Supply it as a build argument when baking it into the image, or provide `StorageProcessJob__MatchApiBaseAddress` as a runtime environment variable.
 
 Use `StorageProcessJob__ProcessingMode=Matching` for the existing flow or `StorageProcessJob__ProcessingMode=Reconciliation` when demographic and address-derived output is required.
 
@@ -39,15 +39,11 @@ docker compose up -d azurite
 > **For Linux users:** `host.docker.internal` is not automatically mapped on Linux. Add `--add-host=host.docker.internal:host-gateway` to the `docker run` command to enable it.
 
 
-If the CSV mapping and matching API base address were supplied as build args, run the job with only the local Azurite connection:
+The production image cannot process a CSV with only the Azurite connection string. At minimum it needs the matching API base address, CSV date format, and source column mappings.
 
-```bash
-docker run --rm \
-  -e 'AzureWebJobsStorage=UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://host.docker.internal' \
-  sui-client-storage-process-job:local
-```
+If `MATCH_API_BASE_ADDRESS` was supplied as a build argument, you can omit `StorageProcessJob__MatchApiBaseAddress` from the runtime environment. CSV mappings and processing mode still need to be supplied at runtime.
 
-Runtime environment variables override values baked into the image. To test overrides locally, pass the .NET configuration keys with `-e`:
+Pass runtime settings with the .NET configuration keys:
 
 ```bash
 docker run --rm \
@@ -67,6 +63,8 @@ docker run --rm \
   -e CsvMatchData__ColumnMappings__Address="${ADDRESS_HISTORY_COLUMN}" \
   sui-client-storage-process-job:local
 ```
+
+Runtime environment variables override values from `appsettings.json` and the baked matching API base address.
 
 `host.docker.internal` lets the job container reach services exposed by the host machine. `UseDevelopmentStorage=true` without `DevelopmentStorageProxyUri` points to `127.0.0.1` inside the job container and will not reach Azurite running outside that container.
 

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
@@ -51,6 +51,7 @@ docker run --rm \
   -e StorageProcessJob__MatchApiBaseAddress=http://host.docker.internal:5000 \
   -e StorageProcessJob__ProcessingMode=Matching \
   -e CsvMatchData__DateFormat=yyyy-MM-dd \
+  -e CsvMatchData__AddressHistoryFormat=TildePipeChronological \
   -e CsvMatchData__ColumnMappings__Id="${SOURCE_ID_COLUMN}" \
   -e CsvMatchData__ColumnMappings__Given="${GIVEN_NAME_COLUMN}" \
   -e CsvMatchData__ColumnMappings__Family="${FAMILY_NAME_COLUMN}" \
@@ -65,6 +66,8 @@ docker run --rm \
 ```
 
 Runtime environment variables override values from `appsettings.json` and the baked matching API base address.
+
+Set `CsvMatchData__AddressHistoryFormat=SemicolonCommaNewestFirst` when the mapped source address column contains semicolon-separated addresses in newest-first order, with each address represented as comma-separated address lines. The default `TildePipeChronological` format keeps the existing `|`-separated records with `~`-separated fields.
 
 `host.docker.internal` lets the job container reach services exposed by the host machine. `UseDevelopmentStorage=true` without `DevelopmentStorageProxyUri` points to `127.0.0.1` inside the job container and will not reach Azurite running outside that container.
 

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/README.md
@@ -11,29 +11,21 @@ docker build \
   .
 ```
 
-CSV mapping and the matching API base address can be baked into the image with build args. This mirrors how a workflow can pass values to `docker build` before pushing the image to ACR.
+The matching API base address can be baked into the image for local use. CSV mappings and processing mode must be provided at runtime so deployment-specific schemas are not stored in the image or repository.
 
 ```bash
 docker build \
   -f src/SUI.Client/SUI.Client.StorageProcessJob/Dockerfile \
   -t sui-client-storage-process-job:local \
   --build-arg MATCH_API_BASE_ADDRESS=http://host.docker.internal:5000 \
-  --build-arg CSV_DATE_FORMAT=yyyy-MM-dd \
-  --build-arg CSV_COLUMN_ID=Id \
-  --build-arg CSV_COLUMN_GIVEN=GivenName \
-  --build-arg CSV_COLUMN_FAMILY=FamilyName \
-  --build-arg CSV_COLUMN_BIRTH_DATE=DOB \
-  --build-arg CSV_COLUMN_EMAIL=EMAIL \
-  --build-arg CSV_COLUMN_POSTCODE=POSTCODE \
-  --build-arg CSV_COLUMN_GENDER=GENDER \
-  --build-arg CSV_COLUMN_PHONE=PHONE \
-  --build-arg CSV_COLUMN_NHS_NUMBER=NHS_NUMBER \
   .
 ```
 
 `MATCH_API_BASE_ADDRESS` has no Dockerfile default. Supply it as a build arg when baking it into the image, or provide `StorageProcessJob__MatchApiBaseAddress` as a runtime environment variable.
 
-The build args map to .NET configuration environment variables in the Dockerfile. For example, `CSV_COLUMN_GIVEN=GivenName` becomes `CsvMatchData__ColumnMappings__Given=GivenName`, which .NET binds to `CsvMatchData:ColumnMappings:Given`.
+Use `StorageProcessJob__ProcessingMode=Matching` for the existing flow or `StorageProcessJob__ProcessingMode=Reconciliation` when demographic and address-derived output is required.
+
+Reconciliation mode appends generic derived columns for age group, four address-history comparisons, source-number presence, and whether the source number equals the matched number. Deployment-specific column mappings must be supplied through protected runtime configuration.
 
 ## Run locally
 
@@ -61,16 +53,18 @@ Runtime environment variables override values baked into the image. To test over
 docker run --rm \
   -e 'AzureWebJobsStorage=UseDevelopmentStorage=true;DevelopmentStorageProxyUri=http://host.docker.internal' \
   -e StorageProcessJob__MatchApiBaseAddress=http://host.docker.internal:5000 \
+  -e StorageProcessJob__ProcessingMode=Matching \
   -e CsvMatchData__DateFormat=yyyy-MM-dd \
-  -e CsvMatchData__ColumnMappings__Id=Id \
-  -e CsvMatchData__ColumnMappings__Given=GivenName \
-  -e CsvMatchData__ColumnMappings__Family=FamilyName \
-  -e CsvMatchData__ColumnMappings__BirthDate=DOB \
-  -e CsvMatchData__ColumnMappings__Email=EMAIL \
-  -e CsvMatchData__ColumnMappings__Postcode=POSTCODE \
-  -e CsvMatchData__ColumnMappings__Gender=GENDER \
-  -e CsvMatchData__ColumnMappings__Phone=PHONE \
-  -e CsvMatchData__ColumnMappings__NhsNumber=NHS_NUMBER \
+  -e CsvMatchData__ColumnMappings__Id="${SOURCE_ID_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Given="${GIVEN_NAME_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Family="${FAMILY_NAME_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__BirthDate="${BIRTH_DATE_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Email="${EMAIL_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Postcode="${POSTCODE_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Gender="${GENDER_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Phone="${PHONE_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__NhsNumber="${SOURCE_NUMBER_COLUMN}" \
+  -e CsvMatchData__ColumnMappings__Address="${ADDRESS_HISTORY_COLUMN}" \
   sui-client-storage-process-job:local
 ```
 

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/StorageProcessJobOptions.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/StorageProcessJobOptions.cs
@@ -15,4 +15,11 @@ public sealed class StorageProcessJobOptions
     public int MessageVisibilityTimeoutMinutes { get; init; } = 10;
     public int MessageVisibilityRenewalIntervalMinutes { get; init; } = 5;
     public string? MatchApiBaseAddress { get; init; }
+    public string ProcessingMode { get; init; } = ProcessingModes.Matching;
+}
+
+public static class ProcessingModes
+{
+    public const string Matching = "Matching";
+    public const string Reconciliation = "Reconciliation";
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -12,20 +12,22 @@
     "MaxDequeueCount": 1,
     "MessageVisibilityTimeoutMinutes": 10,
     "MessageVisibilityRenewalIntervalMinutes": 5,
-    "MatchApiBaseAddress": "http://localhost:5000/matching/"
+    "MatchApiBaseAddress": "http://localhost:5000/matching/",
+    "ProcessingMode": "Matching"
   },
   "CsvMatchData": {
     "DateFormat": "yyyy-MM-dd",
     "ColumnMappings": {
-      "Id": "Id",
+      "Id": "PersonId",
       "Given": "GivenName",
       "Family": "FamilyName",
-      "BirthDate": "DOB",
-      "Email": "EMAIL",
-      "Postcode": "POSTCODE",
-      "Gender": "GENDER",
-      "Phone": "PHONE",
-      "NhsNumber": "NHS_NUMBER"
+      "BirthDate": "BirthDate",
+      "Email": "Email",
+      "Postcode": "Postcode",
+      "Gender": "Gender",
+      "Phone": "Phone",
+      "NhsNumber": "SourceNumber",
+      "Address": "AddressHistory"
     }
   }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -17,6 +17,7 @@
   },
   "CsvMatchData": {
     "DateFormat": "yyyy-MM-dd",
+    "AddressHistoryFormat": "TildePipeChronological",
     "ColumnMappings": {
       "Id": "PersonId",
       "Given": "GivenName",

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
@@ -17,7 +17,8 @@
     "MaxDequeueCount": 1,
     "MessageVisibilityTimeoutMinutes": 10,
     "MessageVisibilityRenewalIntervalMinutes": 5,
-    "MatchApiBaseAddress": ""
+    "MatchApiBaseAddress": "",
+    "ProcessingMode": "Matching"
   },
   "CsvMatchData": {
     "DateFormat": "",
@@ -30,7 +31,8 @@
       "Postcode": "",
       "Gender": "",
       "Phone": "",
-      "NhsNumber": ""
+      "NhsNumber": "",
+      "Address": ""
     }
   }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
@@ -22,6 +22,7 @@
   },
   "CsvMatchData": {
     "DateFormat": "",
+    "AddressHistoryFormat": "TildePipeChronological",
     "ColumnMappings": {
       "Id": "",
       "Given": "",

--- a/tests/E2E.Tests/Client/ReconciliationTests.cs
+++ b/tests/E2E.Tests/Client/ReconciliationTests.cs
@@ -66,7 +66,8 @@ public class ReconciliationTests(AppHostFixture fixture, TempDirectoryFixture te
             logger,
             mappingConfig,
             matchPersonApiService,
-            watcherConfig
+            watcherConfig,
+            new AddressComparisonOrchestrator(new TildePipeChronologicalAddressHistoryParser())
         );
 
         var monitor = new CsvFileMonitor(

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -67,6 +67,9 @@ public class ReconcilePersonRecordOrchestratorTests
             apiClient.Object,
             personParser.Object,
             reconciliationParser.Object,
+            new AddressComparisonOrchestrator(
+                new SemicolonCommaNewestFirstAddressHistoryParser()
+            ),
             Options.Create(
                 new PersonMatchingOptions
                 {

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -1,0 +1,104 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Shared.Models;
+using SUI.Client.Core.Application.Interfaces;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
+
+namespace Unit.Tests.Client.CoreTests.ApplicationTests.UseCaseTests.ReconcilePeopleTests;
+
+public class ReconcilePersonRecordOrchestratorTests
+{
+    [Fact]
+    public async Task Should_ReconcileParsedRecordAndRetainDerivedInputs()
+    {
+        var apiClient = new Mock<IMatchingApiClient>();
+        var personParser = new Mock<IPersonSpecParser<string>>();
+        var reconciliationParser = new Mock<IReconciliationDataParser<string>>();
+        personParser
+            .Setup(parser => parser.Parse("record"))
+            .Returns(
+                new PersonSpecification
+                {
+                    Given = "Jane",
+                    Family = "Doe",
+                    BirthDate = new DateOnly(2012, 5, 10),
+                    RawBirthDate = ["2012-05-10"],
+                    AddressPostalCode = "AA1 1AA",
+                }
+            );
+        reconciliationParser
+            .Setup(parser => parser.Parse("record"))
+            .Returns(
+                new ReconciliationSourceData(
+                    "9999999993",
+                    "10 Example Road, Exampletown, AA1 1AA"
+                )
+            );
+        apiClient
+            .Setup(client =>
+                client.ReconcilePersonAsync(
+                    It.IsAny<ReconciliationRequest>(),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(
+                new ReconciliationResponse
+                {
+                    Status = ReconciliationStatus.NoDifferences,
+                    SearchId = "search-id",
+                    MatchingResult = new MatchResult
+                    {
+                        MatchStatus = MatchStatus.Match,
+                        NhsNumber = "9999999993",
+                        Score = 0.96m,
+                    },
+                    Person = new NhsPerson
+                    {
+                        NhsNumber = "9999999993",
+                        AddressPostalCodes = ["AA1 1AA"],
+                        AddressHistory = ["current~10 Example Road~Exampletown~AA1 1AA"],
+                    },
+                }
+            );
+        var sut = new ReconcilePersonRecordOrchestrator<string>(
+            NullLogger<ReconcilePersonRecordOrchestrator<string>>.Instance,
+            apiClient.Object,
+            personParser.Object,
+            reconciliationParser.Object,
+            Options.Create(
+                new PersonMatchingOptions
+                {
+                    SearchStrategy = Shared.SharedConstants.SearchStrategy.Strategies.Strategy4,
+                    StrategyVersion = 2,
+                }
+            )
+        );
+
+        var result = Assert.Single(
+            await sut.ProcessAsync(["record"], "input.csv", CancellationToken.None)
+        );
+
+        apiClient.Verify(
+            client =>
+                client.ReconcilePersonAsync(
+                    It.Is<ReconciliationRequest>(request =>
+                        request.NhsNumber == "9999999993"
+                        && request.SearchStrategy
+                            == Shared.SharedConstants.SearchStrategy.Strategies.Strategy4
+                    ),
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+        Assert.True(result.IsSuccess);
+        Assert.Equal("search-id", result.ApiResult!.SearchId);
+        Assert.Equal(new DateOnly(2012, 5, 10), result.SourceBirthDate);
+        Assert.Equal("9999999993", result.SourceNhsNumber);
+        Assert.Equal(
+            AddressComparisonResult.AddressMatchStatus.Matched,
+            result.AddressComparisonResults!.PrimaryAddressSame.Status
+        );
+    }
+}

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/CsvMatchingHeadersProviderTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/CsvMatchingHeadersProviderTests.cs
@@ -64,7 +64,7 @@ public class CsvMatchingHeadersProviderTests
 
         var result = sut.GetOptionalHeaders();
 
-        Assert.Equal(["EmailAddress", "Gender", "Telephone"], result);
+        Assert.Equal(["EmailAddress", "Gender", "Telephone", "NhsNumber"], result);
         Assert.DoesNotContain("PersonId", result);
         Assert.DoesNotContain("Forename", result);
         Assert.DoesNotContain("Surname", result);

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
@@ -202,9 +202,11 @@ public class MatchingApiClientTests
                 ItExpr.IsAny<CancellationToken>()
             )
             .Returns<HttpRequestMessage, CancellationToken>(
-                async (request, _) =>
+                async (request, cancellationToken) =>
                 {
-                    sentPayload = await request.Content!.ReadFromJsonAsync<ReconciliationRequest>();
+                    sentPayload = await request.Content!.ReadFromJsonAsync<ReconciliationRequest>(
+                        cancellationToken
+                    );
                     return new HttpResponseMessage
                     {
                         StatusCode = HttpStatusCode.OK,

--- a/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/InfrastructureTests/MatchingApiClientTests.cs
@@ -188,4 +188,60 @@ public class MatchingApiClientTests
             sut.MatchPersonAsync(new SearchSpecification(), CancellationToken.None)
         );
     }
+
+    [Fact]
+    public async Task Should_PostReconciliationRequestToReconciliationEndpoint()
+    {
+        ReconciliationRequest? sentPayload = null;
+        var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handlerMock
+            .Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Returns<HttpRequestMessage, CancellationToken>(
+                async (request, _) =>
+                {
+                    sentPayload = await request.Content!.ReadFromJsonAsync<ReconciliationRequest>();
+                    return new HttpResponseMessage
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        Content = JsonContent.Create(
+                            new ReconciliationResponse
+                            {
+                                Status = ReconciliationStatus.NoDifferences,
+                            }
+                        ),
+                    };
+                }
+            );
+        var sut = new MatchingApiClient(
+            new HttpClient(handlerMock.Object)
+            {
+                BaseAddress = new Uri("http://localhost:5000/matching/"),
+            }
+        );
+
+        var result = await sut.ReconcilePersonAsync(
+            new ReconciliationRequest { NhsNumber = "9999999993", Given = "Jane" },
+            CancellationToken.None
+        );
+
+        Assert.NotNull(sentPayload);
+        Assert.Equal("9999999993", sentPayload!.NhsNumber);
+        Assert.Equal(ReconciliationStatus.NoDifferences, result!.Status);
+        handlerMock
+            .Protected()
+            .Verify(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.Is<HttpRequestMessage>(request =>
+                    request.RequestUri!.ToString()
+                    == "http://localhost:5000/matching/api/v1/reconciliation"
+                ),
+                ItExpr.IsAny<CancellationToken>()
+            );
+    }
 }

--- a/tests/Unit.Tests/Client/CsvProcessorTests.cs
+++ b/tests/Unit.Tests/Client/CsvProcessorTests.cs
@@ -12,6 +12,7 @@ using Shared.Models;
 using Shared.Services;
 using Shared.Util;
 using SUI.Client.Core;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 using SUI.Client.Core.Infrastructure.FileSystem;
 using Unit.Tests.Util;
 using Unit.Tests.Util.Adapters;
@@ -1502,7 +1503,8 @@ public class CsvProcessorTests(ITestOutputHelper testOutputHelper)
             new Mock<ILogger<ReconciliationCsvFileProcessor>>().Object,
             new CsvMappingConfig(),
             new Mock<IMatchingService>().Object, // All responses are null
-            Options.Create(new CsvWatcherConfig { SearchStrategy = "4" })
+            Options.Create(new CsvWatcherConfig { SearchStrategy = "4" }),
+            new AddressComparisonOrchestrator(new TildePipeChronologicalAddressHistoryParser())
         );
 
         // Write input file

--- a/tests/Unit.Tests/Client/ParserTests/AddressDelimiterParserTests.cs
+++ b/tests/Unit.Tests/Client/ParserTests/AddressDelimiterParserTests.cs
@@ -8,8 +8,26 @@ public class AddressDelimiterParserTests
     [Fact]
     public void ParseHistory_ParsesNewestFirstCommaSeparatedAddresses()
     {
-        var result = AddressParser.ParseHistory(
+        var parser = new SemicolonCommaNewestFirstAddressHistoryParser();
+
+        var result = parser.Parse(
             "10 Example Road, Exampletown, AA1 1AA; 20 Previous Street, Othertown, BB2 2BB",
+            "AA1 1AA"
+        );
+
+        Assert.Equal(2, result.Addresses.Count);
+        Assert.NotNull(result.PrimaryAddress);
+        Assert.Equal("10", result.PrimaryAddress!.AddressLineOne);
+        Assert.Equal("AA11AA", result.PrimaryAddress.Postcode);
+    }
+
+    [Fact]
+    public void ParseHistory_UsesConfiguredFormat_WhenCommaSeparatedAddressContainsTilde()
+    {
+        var parser = new SemicolonCommaNewestFirstAddressHistoryParser();
+
+        var result = parser.Parse(
+            "10 Example~ Road, Exampletown, AA1 1AA; 20 Previous Street, Othertown, BB2 2BB",
             "AA1 1AA"
         );
 
@@ -100,11 +118,12 @@ public class AddressDelimiterParserTests
     [Fact]
     public void ParseHistory_ParsesMultipleRecords_DelimitedByPipe()
     {
+        var parser = new TildePipeChronologicalAddressHistoryParser();
         const string primaryPostcode = "YO2 7GB";
         const string historyString =
             "1~2 bob lane~Somewhere~YO1 6GA|2~3 alice road~Elsewhere~YO2 7GB";
 
-        var result = AddressParser.ParseHistory(historyString, primaryPostcode);
+        var result = parser.Parse(historyString, primaryPostcode);
 
         Assert.NotNull(result);
         Assert.Equal(2, result.Addresses.Count);
@@ -124,7 +143,9 @@ public class AddressDelimiterParserTests
         int expectedCount
     )
     {
-        var result = AddressParser.ParseHistory(historyString, primaryPostcode);
+        var parser = new TildePipeChronologicalAddressHistoryParser();
+
+        var result = parser.Parse(historyString, primaryPostcode);
 
         Assert.NotNull(result);
         Assert.Equal(expectedCount, result.Addresses.Count);
@@ -150,7 +171,9 @@ public class AddressDelimiterParserTests
         string expectedPostcode
     )
     {
-        var result = AddressParser.ParseHistory(historyString, primaryPostcode);
+        var parser = new TildePipeChronologicalAddressHistoryParser();
+
+        var result = parser.Parse(historyString, primaryPostcode);
 
         Assert.NotNull(result);
         Assert.NotNull(result.PrimaryAddress);

--- a/tests/Unit.Tests/Client/ParserTests/AddressDelimiterParserTests.cs
+++ b/tests/Unit.Tests/Client/ParserTests/AddressDelimiterParserTests.cs
@@ -6,6 +6,20 @@ namespace Unit.Tests.Client.ParserTests;
 public class AddressDelimiterParserTests
 {
     [Fact]
+    public void ParseHistory_ParsesNewestFirstCommaSeparatedAddresses()
+    {
+        var result = AddressParser.ParseHistory(
+            "10 Example Road, Exampletown, AA1 1AA; 20 Previous Street, Othertown, BB2 2BB",
+            "AA1 1AA"
+        );
+
+        Assert.Equal(2, result.Addresses.Count);
+        Assert.NotNull(result.PrimaryAddress);
+        Assert.Equal("10", result.PrimaryAddress!.AddressLineOne);
+        Assert.Equal("AA11AA", result.PrimaryAddress.Postcode);
+    }
+
+    [Fact]
     public void ParseRecord_ParsesHouseFromSecondSegment_AndPostcodeFromLast()
     {
         const string historyString = "1~2 bob lane~Somewhere~YO1 6GA";

--- a/tests/Unit.Tests/Client/ParserTests/CsvPersonSpecParserTests.cs
+++ b/tests/Unit.Tests/Client/ParserTests/CsvPersonSpecParserTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using Shared.Models;
+using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Infrastructure.CsvParsers;
 
@@ -23,7 +24,8 @@ public class CsvPersonSpecParserTests
                     Postcode = "Postcode",
                     Gender = "Gender",
                     Phone = "Phone",
-                    NhsNumber = "NhsNumber",
+                    NhsNumber = "SourceNumber",
+                    Address = "AddressHistory",
                 },
             }
         );
@@ -142,5 +144,34 @@ public class CsvPersonSpecParserTests
 
         Assert.Equal("CustomValue1", result.OptionalProperties["CustomField1"]);
         Assert.Equal("CustomValue2", result.OptionalProperties["CustomField2"]);
+    }
+
+    [Fact]
+    public void Should_ExcludeMappedReconciliationFieldsFromOptionalProperties()
+    {
+        var sut = new CsvPersonSpecParser(CreateDefaultOptions());
+        var csvRecord = new CsvRecordDto(
+            new Dictionary<string, string>
+            {
+                ["GivenName"] = "Jane",
+                ["FamilyName"] = "Doe",
+                ["DOB"] = "2012-05-10",
+                ["SourceNumber"] = "9999999993",
+                ["AddressHistory"] = "10 Example Road, Exampletown, AA1 1AA",
+                ["AnalysisField"] = "Value",
+            }
+        );
+
+        var person = sut.Parse(csvRecord);
+        var reconciliationData = ((IReconciliationDataParser<CsvRecordDto>)sut).Parse(csvRecord);
+
+        Assert.DoesNotContain("SourceNumber", person.OptionalProperties.Keys);
+        Assert.DoesNotContain("AddressHistory", person.OptionalProperties.Keys);
+        Assert.Equal("Value", person.OptionalProperties["AnalysisField"]);
+        Assert.Equal("9999999993", reconciliationData.NhsNumber);
+        Assert.Equal(
+            "10 Example Road, Exampletown, AA1 1AA",
+            reconciliationData.AddressHistory
+        );
     }
 }

--- a/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
@@ -3,10 +3,12 @@ using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Shared.Models;
+using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
 using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
+using SUI.Client.Core.Infrastructure.FileSystem;
 using SUI.Client.StorageProcessJob;
 using SUI.Client.StorageProcessJob.Application;
 using SUI.Client.StorageProcessJob.Application.Interfaces;
@@ -267,6 +269,159 @@ public class ExportFullResultsAsyncTests
                 ),
             Times.Once
         );
+    }
+
+    [Fact]
+    public async Task Should_ProcessAndPreserveCompleteGenericSourceSchema()
+    {
+        var columnMappings = new CsvMatchDataOptions.Headers
+        {
+            Id = "RecordKey",
+            Given = "FirstName",
+            Family = "LastName",
+            BirthDate = "BirthDate",
+            Postcode = "PostalCode",
+            Gender = "Sex",
+            Email = "Email",
+            Phone = "Phone",
+            NhsNumber = "SourceHealthNumber",
+            Address = "ResidenceHistory",
+        };
+        var csvOptions = Options.Create(
+            new CsvMatchDataOptions
+            {
+                DateFormat = "yyyy-MM-dd",
+                ColumnMappings = columnMappings,
+            }
+        );
+        var originalFields = new Dictionary<string, string>
+        {
+            [columnMappings.Id] = "record-001",
+            [columnMappings.NhsNumber!] = "9999999993",
+            [columnMappings.Given] = "Jamie",
+            [columnMappings.Family] = "Taylor",
+            [columnMappings.Postcode] = "AA1 1AA",
+            [columnMappings.BirthDate] = "2000-01-01",
+            [columnMappings.Gender] = "female",
+            [columnMappings.Address!] =
+                "10 Example Road, Exampletown, AA1 1AA; 20 Previous Street, Othertown, BB2 2BB",
+        };
+        foreach (var index in Enumerable.Range(1, 27))
+        {
+            originalFields[$"AnalysisField{index:00}"] = $"AnalysisValue{index:00}";
+        }
+        Assert.Equal(35, originalFields.Count);
+
+        var source = new CsvRecordDto(originalFields);
+        var parser = new CsvPersonSpecParser(csvOptions);
+        var person = parser.Parse(source);
+        var reconciliationData = ((IReconciliationDataParser<CsvRecordDto>)parser).Parse(source);
+
+        Assert.Equal("Jamie", person.Given);
+        Assert.Equal("Taylor", person.Family);
+        Assert.Equal(new DateOnly(2000, 1, 1), person.BirthDate);
+        Assert.Equal("AA1 1AA", person.AddressPostalCode);
+        Assert.Equal("female", person.Gender);
+        Assert.Equal(27, person.OptionalProperties.Count);
+        Assert.All(
+            Enumerable.Range(1, 27),
+            index =>
+                Assert.Equal(
+                    $"AnalysisValue{index:00}",
+                    person.OptionalProperties[$"AnalysisField{index:00}"]
+                )
+        );
+        Assert.DoesNotContain(columnMappings.NhsNumber!, person.OptionalProperties.Keys);
+        Assert.DoesNotContain(columnMappings.Address!, person.OptionalProperties.Keys);
+        Assert.Equal("9999999993", reconciliationData.NhsNumber);
+        Assert.Equal(originalFields[columnMappings.Address!], reconciliationData.AddressHistory);
+
+        BinaryData? uploadedContent = null;
+        var blobStorageClient = new Mock<IBlobStorageClient>();
+        blobStorageClient
+            .Setup(client =>
+                client.UploadBlobAsync(
+                    "processed",
+                    BlobNames.FullResultsBlobName,
+                    It.IsAny<BinaryData>(),
+                    "text/csv",
+                    CancellationToken.None
+                )
+            )
+            .Callback<string, string, BinaryData, string, CancellationToken>(
+                (_, _, content, _, _) => uploadedContent = content
+            )
+            .Returns(Task.CompletedTask);
+        var sut = new MatchResultsService(
+            _logger.Object,
+            blobStorageClient.Object,
+            Options.Create(
+                new StorageProcessJobOptions
+                {
+                    ProcessedContainerName = "processed",
+                    ProcessingMode = ProcessingModes.Reconciliation,
+                }
+            ),
+            csvOptions
+        );
+        var processedRecord = CreateMatchedRecord(
+            originalFields,
+            true,
+            MatchStatus.Match,
+            0.96m,
+            "9999999993",
+            "search-id-1"
+        );
+        processedRecord.ReconciliationResult = new ReconciliationResponse
+        {
+            Status = ReconciliationStatus.NoDifferences,
+        };
+        processedRecord.SourceBirthDate = person.BirthDate;
+        processedRecord.SourceNhsNumber = reconciliationData.NhsNumber;
+        processedRecord.AddressComparisonResults = new AddressComparisonResults
+        {
+            PrimaryAddressSame = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+            AddressHistoriesIntersect = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+            PrimaryCMSAddressInPDSHistory = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+            PrimaryPDSAddressInCMSHistory = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+        };
+
+        await sut.ExportFullResultsAsync(
+            BlobNames,
+            "generic-source.csv",
+            [processedRecord],
+            CancellationToken.None
+        );
+
+        Assert.NotNull(uploadedContent);
+        using var outputReader = new StringReader(uploadedContent!.ToString());
+        var (outputHeaders, outputRecords) = await CsvRecordReader.ReadCsvTextAsync(outputReader);
+        var outputRecord = Assert.Single(outputRecords);
+
+        Assert.Equal(46, outputHeaders.Count);
+        Assert.All(
+            originalFields,
+            field => Assert.Equal(field.Value, outputRecord[field.Key])
+        );
+        Assert.Equal("NoDifferences", outputRecord["SUI_Status"]);
+        Assert.Equal("0.96", outputRecord["SUI_Score"]);
+        Assert.Equal("9999999993", outputRecord["SUI_NHSNo"]);
+        Assert.Equal("search-id-1", outputRecord["SUI_SearchId"]);
+        Assert.Equal("Over 18 years", outputRecord["SUI_AgeGroup"]);
+        Assert.Equal("Matched", outputRecord["SUI_PrimaryAddressSame"]);
+        Assert.Equal("Matched", outputRecord["SUI_AddressHistoriesIntersect"]);
+        Assert.Equal("Matched", outputRecord["SUI_PrimarySourceAddressInPDSHistory"]);
+        Assert.Equal("Matched", outputRecord["SUI_PrimaryPDSAddressInSourceHistory"]);
+        Assert.Equal("Yes", outputRecord["SUI_SourceNhsNumberPresent"]);
+        Assert.Equal("Yes", outputRecord["SUI_SourceNhsNumberEqualsMatchedNhsNumber"]);
     }
 
     private static ProcessedMatchRecord<CsvRecordDto> CreateMatchedRecord(

--- a/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
@@ -5,6 +5,7 @@ using Moq;
 using Shared.Models;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
+using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
 using SUI.Client.StorageProcessJob;
 using SUI.Client.StorageProcessJob.Application;
@@ -178,6 +179,89 @@ public class ExportFullResultsAsyncTests
                     "processed",
                     "20260120120000_test-file/test-file_full-results.csv",
                     It.Is<BinaryData>(data => data.ToString() == FullResultsCsvWithErrorRow),
+                    "text/csv",
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
+    public async Task Should_WriteDerivedFields_When_ReconciliationModeIsEnabled()
+    {
+        var blobStorageClient = new Mock<IBlobStorageClient>();
+        var sut = new MatchResultsService(
+            _logger.Object,
+            blobStorageClient.Object,
+            Options.Create(
+                new StorageProcessJobOptions
+                {
+                    ProcessedContainerName = "processed",
+                    ProcessingMode = ProcessingModes.Reconciliation,
+                }
+            ),
+            Options.Create(
+                new CsvMatchDataOptions
+                {
+                    DateFormat = "yyyy-MM-dd",
+                    ColumnMappings = new CsvMatchDataOptions.Headers
+                    {
+                        Id = "Id",
+                        Given = "GivenName",
+                        Family = "FamilyName",
+                        BirthDate = "DOB",
+                        Postcode = "Postcode",
+                    },
+                }
+            )
+        );
+        var record = CreateMatchedRecord(
+            new Dictionary<string, string> { ["Id"] = "1111" },
+            true,
+            MatchStatus.Match,
+            0.96m,
+            "9999999993",
+            "search-id-1"
+        );
+        record.ReconciliationResult = new ReconciliationResponse
+        {
+            Status = ReconciliationStatus.NoDifferences,
+        };
+        record.SourceBirthDate = new DateOnly(2000, 1, 1);
+        record.SourceNhsNumber = "9999999993";
+        record.AddressComparisonResults = new AddressComparisonResults
+        {
+            PrimaryAddressSame = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+            AddressHistoriesIntersect = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Unmatched
+            ),
+            PrimaryCMSAddressInPDSHistory = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Uncertain,
+                AddressComparisonResult.AddressMatchReason.FlatMissing
+            ),
+            PrimaryPDSAddressInCMSHistory = new AddressComparisonResult(
+                AddressComparisonResult.AddressMatchStatus.Matched
+            ),
+        };
+        var expected =
+            $"Id,SUI_Status,SUI_Score,SUI_NHSNo,SUI_SearchId,SUI_AgeGroup,SUI_PrimaryAddressSame,SUI_AddressHistoriesIntersect,SUI_PrimarySourceAddressInPDSHistory,SUI_PrimaryPDSAddressInSourceHistory,SUI_SourceNhsNumberPresent,SUI_SourceNhsNumberEqualsMatchedNhsNumber{Environment.NewLine}"
+            + $"1111,NoDifferences,0.96,9999999993,search-id-1,Over 18 years,Matched,Unmatched,Uncertain-FlatMissing,Matched,Yes,Yes{Environment.NewLine}";
+
+        await sut.ExportFullResultsAsync(
+            BlobNames,
+            "test-file.csv",
+            [record],
+            CancellationToken.None
+        );
+
+        blobStorageClient.Verify(
+            client =>
+                client.UploadBlobAsync(
+                    "processed",
+                    BlobNames.FullResultsBlobName,
+                    It.Is<BinaryData>(data => data.ToString() == expected),
                     "text/csv",
                     CancellationToken.None
                 ),

--- a/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
+++ b/tests/Unit.Tests/Client/StorageProcessJob/MatchResultsServiceTests/ExportFullResultsAsyncTests.cs
@@ -272,6 +272,77 @@ public class ExportFullResultsAsyncTests
     }
 
     [Fact]
+    public async Task Should_WriteFallbackDerivedFields_When_ReconciliationDataIsUnavailable()
+    {
+        var blobStorageClient = new Mock<IBlobStorageClient>();
+        var sut = new MatchResultsService(
+            _logger.Object,
+            blobStorageClient.Object,
+            Options.Create(
+                new StorageProcessJobOptions
+                {
+                    ProcessedContainerName = "processed",
+                    ProcessingMode = ProcessingModes.Reconciliation,
+                }
+            ),
+            Options.Create(
+                new CsvMatchDataOptions
+                {
+                    DateFormat = "yyyy-MM-dd",
+                    ColumnMappings = new CsvMatchDataOptions.Headers
+                    {
+                        Id = "Id",
+                        Given = "GivenName",
+                        Family = "FamilyName",
+                        BirthDate = "DOB",
+                        Postcode = "Postcode",
+                    },
+                }
+            )
+        );
+        var missingSourceData = CreateMatchedRecord(
+            new Dictionary<string, string> { ["Id"] = "1111" },
+            true,
+            MatchStatus.Match,
+            0.96m,
+            "9999999993",
+            "search-id-1"
+        );
+        var differentSourceNhsNumber = CreateMatchedRecord(
+            new Dictionary<string, string> { ["Id"] = "2222" },
+            true,
+            MatchStatus.Match,
+            0.95m,
+            "9999999993",
+            "search-id-2"
+        );
+        differentSourceNhsNumber.SourceNhsNumber = "1111111111";
+        var expected =
+            $"Id,SUI_Status,SUI_Score,SUI_NHSNo,SUI_SearchId,SUI_AgeGroup,SUI_PrimaryAddressSame,SUI_AddressHistoriesIntersect,SUI_PrimarySourceAddressInPDSHistory,SUI_PrimaryPDSAddressInSourceHistory,SUI_SourceNhsNumberPresent,SUI_SourceNhsNumberEqualsMatchedNhsNumber{Environment.NewLine}"
+            + $"1111,Match,0.96,9999999993,search-id-1,Unknown,NoComparison,NoComparison,NoComparison,NoComparison,No,No{Environment.NewLine}"
+            + $"2222,Match,0.95,9999999993,search-id-2,Unknown,NoComparison,NoComparison,NoComparison,NoComparison,Yes,No{Environment.NewLine}";
+
+        await sut.ExportFullResultsAsync(
+            BlobNames,
+            "test-file.csv",
+            [missingSourceData, differentSourceNhsNumber],
+            CancellationToken.None
+        );
+
+        blobStorageClient.Verify(
+            client =>
+                client.UploadBlobAsync(
+                    "processed",
+                    BlobNames.FullResultsBlobName,
+                    It.Is<BinaryData>(data => data.ToString() == expected),
+                    "text/csv",
+                    CancellationToken.None
+                ),
+            Times.Once
+        );
+    }
+
+    [Fact]
     public async Task Should_ProcessAndPreserveCompleteGenericSourceSchema()
     {
         var columnMappings = new CsvMatchDataOptions.Headers


### PR DESCRIPTION
## Summary

Adds configurable reconciliation-mode processing for storage jobs so incoming CSV schemas can be mapped at runtime without baking source-specific column names into the image or repository.

Existing matching behaviour remains the default. Deployments can opt into reconciliation mode when derived comparison fields are required in the output.

## Changes

- Added reconciliation input parsing and orchestration for CSV records, including configurable source address and NHS number handling for derived fields.
- Added runtime `StorageProcessJob:ProcessingMode` selection and protected deployment-time configuration support for storage job settings.
- Made storage job runtime configuration required for blob-event-processor deployments so missing mappings fail early.
- Added explicit source address-history parser selection with `CsvMatchData__AddressHistoryFormat`, supporting the existing `TildePipeChronological` format and the new `SemicolonCommaNewestFirst` format.
- Updated full result export to include reconciliation-derived DOB, address, and NHS-number fields when reconciliation mode is enabled.
- Added generic schema coverage tests for all supported mapped source columns, plus parser/client/orchestrator regression coverage.

## Validation

- Focused unit tests covering parser, CSV processor, reconciliation orchestrator, and full-results export paths.
- E2E reconciliation test.
- Manual local tests using local stub APIs.
- `az bicep build --file infra/stacks/blob-event-processor/main.bicep`
- `az bicep build --file infra/stacks/blob-event-processor/subscription.bicep`

## Rollout notes

- Existing deployments continue to use matching mode unless reconciliation mode is explicitly configured.
- Source-specific column mappings should be supplied through protected deployment/environment configuration, not committed to the repo.
- Configure `CsvMatchData__AddressHistoryFormat=SemicolonCommaNewestFirst` where source address history is semicolon-delimited, comma-line formatted, and newest-first.
- Reconciliation mode should be tested in the target environment after a new storage job image has been built.
