### PR TITLE
feat: 1847 - log optional

### DIFF
--- a/documentation/docs/runbooks/blob-processor-local-runbook.md
+++ b/documentation/docs/runbooks/blob-processor-local-runbook.md
@@ -25,6 +25,8 @@ or the storage processor event job image.
   [Publish the storage processor image to Azure Container Registry](#publish-the-storage-processor-image-to-azure-container-registry).
 - Final application deployment after publishing images: follow
   [Redeploy infrastructure after publishing images](#redeploy-infrastructure-after-publishing-images).
+- Add optional reconciliation properties to logs: follow
+  [Add optional properties to storage processor logs](#add-optional-properties-to-storage-processor-logs).
 - Smoke test: follow [Smoke test the deployment](#smoke-test-the-deployment).
 
 ## Full deployment flow
@@ -32,14 +34,15 @@ or the storage processor event job image.
 1. [Pick a branch, tag or commit to deploy](#pick-a-branch-tag-or-commit-to-deploy).
 2. [Run dotnet restore, build and tests](#run-dotnet-restore-build-and-tests).
 3. [Common setup](#common-setup).
-4. [Infrastructure deployment variables](#infrastructure-deployment-variables).
-5. [Run the infrastructure what-if](#run-the-infrastructure-what-if).
-6. [Run the infrastructure deploy](#run-the-infrastructure-deploy).
-7. [Add the NHS Digital secrets to Key Vault](#add-the-nhs-digital-secrets-to-key-vault).
-8. [Publish the API images to Azure Container Registry](#publish-the-api-images-to-azure-container-registry).
-9. [Publish the storage processor image to Azure Container Registry](#publish-the-storage-processor-image-to-azure-container-registry).
-10. [Redeploy infrastructure after publishing images](#redeploy-infrastructure-after-publishing-images).
-11. [Smoke test the deployment](#smoke-test-the-deployment).
+4. [Add optional properties to storage processor logs](#add-optional-properties-to-storage-processor-logs), if required.
+5. [Infrastructure deployment variables](#infrastructure-deployment-variables).
+6. [Run the infrastructure what-if](#run-the-infrastructure-what-if).
+7. [Run the infrastructure deploy](#run-the-infrastructure-deploy).
+8. [Add the NHS Digital secrets to Key Vault](#add-the-nhs-digital-secrets-to-key-vault).
+9. [Publish the API images to Azure Container Registry](#publish-the-api-images-to-azure-container-registry).
+10. [Publish the storage processor image to Azure Container Registry](#publish-the-storage-processor-image-to-azure-container-registry).
+11. [Redeploy infrastructure after publishing images](#redeploy-infrastructure-after-publishing-images).
+12. [Smoke test the deployment](#smoke-test-the-deployment).
 
 ## Pick a branch, tag or commit to deploy
 
@@ -110,6 +113,31 @@ STORAGE_PROCESS_JOB_CONFIGURATION='<protected-storage-process-job-configuration-
 ```
 
 `STORAGE_PROCESS_JOB_CONFIGURATION` is passed to the ACA job as runtime environment configuration. It must include the storage job processing mode and CSV mapping keys before the storage processor can process files. Keep deployment-specific source column names in the approved external runbook, not in this repository.
+
+## Add optional properties to storage processor logs
+
+Use this section when the reconciliation processor must include selected optional CSV fields in its structured logs.
+
+`OptionalPropertiesLog` is configured through the same protected `STORAGE_PROCESS_JOB_CONFIGURATION` JSON object as the
+storage job processing mode and CSV mappings. Add one indexed `OptionalPropertiesLog__Fields__<index>` entry for each
+optional CSV column that can be logged.
+
+Example shape:
+
+```bash
+STORAGE_PROCESS_JOB_CONFIGURATION='{
+  "StorageProcessJob__ProcessingMode": "Reconciliation",
+  "OptionalPropertiesLog__Fields__0": "free_school_meals",
+  "OptionalPropertiesLog__Fields__1": "case_status"
+}'
+```
+
+The field names must match the source CSV column names after excluding columns already mapped under
+`CsvMatchData__ColumnMappings`. Matching is case-insensitive. If they do not match, then they will not be logged.
+
+When configured, the reconciliation processor writes the selected values to the
+`RECONCILIATION_OPTIONAL_PROPERTIES` log entry and adds them to the logging scope with an `Optional_` prefix. Fields not
+listed in `OptionalPropertiesLog__Fields` are not included in that optional-properties log entry.
 
 Load the variables into your terminal session, derive the common deployment values, and select the Azure subscription:
 

--- a/infra/modules/blob-event-processor/container-app-job.bicep
+++ b/infra/modules/blob-event-processor/container-app-job.bicep
@@ -44,6 +44,10 @@ param imageTag string
 param matchApiBaseAddress string
 
 @secure()
+@description('The Application Insights connection string')
+param applicationInsightsConnectionString string
+
+@secure()
 @description('Runtime configuration values for the storage process job.')
 param storageProcessJobConfiguration object
 
@@ -110,6 +114,12 @@ resource storageProcessJob 'Microsoft.App/jobs@2024-10-02-preview' = {
           identity: managedIdentityId
         }
       ]
+      secrets: [
+        {
+          name: 'app-insights-connection-string'
+          value: applicationInsightsConnectionString
+        }
+      ]
       eventTriggerConfig: {
         replicaCompletionCount: 1
         parallelism: 1
@@ -162,6 +172,22 @@ resource storageProcessJob 'Microsoft.App/jobs@2024-10-02-preview' = {
               {
                 name: 'AZURE_CLIENT_ID'
                 value: managedIdentityClientId
+              }
+              {
+                name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES'
+                value: 'true'
+              }
+              {
+                name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES'
+                value: 'true'
+              }
+              {
+                name: 'OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY'
+                value: 'in_memory'
+              }
+              {
+                name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+                secretRef: 'app-insights-connection-string'
               }
             ],
             storageProcessJobConfigurationEnvironment

--- a/infra/stacks/blob-event-processor/main.bicep
+++ b/infra/stacks/blob-event-processor/main.bicep
@@ -285,6 +285,7 @@ module storageProcessJob '../../modules/blob-event-processor/container-app-job.b
     containerRegistryServer: containerRegistry.outputs.endpoint
     imageTag: storageProcessJobImageTag
     matchApiBaseAddress: 'https://matching-api.internal.${containerAppEnvironment.outputs.defaultDomain}'
+    applicationInsightsConnectionString: observability.outputs.applicationInsightsConnectionString
     storageProcessJobConfiguration: storageProcessJobConfiguration
     tags: tags
     includeRoleAssignments: includeRoleAssignments

--- a/scripts/test-storage-process-function.ps1
+++ b/scripts/test-storage-process-function.ps1
@@ -75,13 +75,13 @@ if (-not [string]::IsNullOrWhiteSpace($directory)) {
 
 # PDS test data https://digital.nhs.uk/developer/api-catalogue/personal-demographics-service-fhir/pds-fhir-api-test-data#general-tests
 $csvContent = @"
-Id,GivenName,FamilyName,DOB,Postcode,AdditionalColumn1
-1001,octavia,chislett,2008-09-20,,AdditionalValue1
-1002,beryl,shipperbottom,2011-05-09,KT21 1LJ,AdditionalValue1
-1003,briar,anderton,2009-02-15,KT21 1JA,AdditionalValue1
-1004,percy,gilman,2011-01-28,KT21 1EJ,AdditionalValue1
-1005,red,flindall,2011-05-17,KT20 6XJ,AdditionalValue1
-1006,monte,fielding,2008-05-21,KT21 1DJ,AdditionalValue1
+PersonId,GivenName,FamilyName,BirthDate,Postcode,free_school_meals,AdditionalColumn1
+1001,octavia,chislett,2008-09-20,,yes,AdditionalValue1
+1002,beryl,shipperbottom,2011-05-09,KT21 1LJ,no,AdditionalValue1
+1003,briar,anderton,2009-02-15,KT21 1JA,yes,AdditionalValue1
+1004,percy,gilman,2011-01-28,KT21 1EJ,no,AdditionalValue1
+1005,red,flindall,2011-05-17,KT20 6XJ,yes,AdditionalValue1
+1006,monte,fielding,2008-05-21,KT21 1DJ,no,AdditionalValue1
 "@
 
 Set-Content -Path $LocalFilePath -Value $csvContent -Encoding utf8NoBOM

--- a/src/SUI.Client/SUI.Client.Core/Application/Models/OptionalPropertiesLog.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/Models/OptionalPropertiesLog.cs
@@ -1,0 +1,8 @@
+namespace SUI.Client.Core.Application.Models;
+
+public sealed class OptionalPropertiesLog
+{
+    public const string SectionName = "OptionalPropertiesLog";
+
+    public Dictionary<string, string> Fields { get; init; } = new();
+}

--- a/src/SUI.Client/SUI.Client.Core/Application/Models/OptionalPropertiesLog.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/Models/OptionalPropertiesLog.cs
@@ -4,5 +4,5 @@ public sealed class OptionalPropertiesLog
 {
     public const string SectionName = "OptionalPropertiesLog";
 
-    public Dictionary<string, string> Fields { get; init; } = new();
+    public List<string> Fields { get; init; } = [];
 }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Shared.Models;
@@ -17,6 +18,16 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
     IOptions<OptionalPropertiesLog> optionalPropertiesLogOptions
 ) : IMatchPersonRecordOrchestrator<TSource>
 {
+    private const string OptionalPropertiesEventName = "RECONCILIATION_OPTIONAL_PROPERTIES";
+    private const string OptionalPropertyPrefix = "Optional_";
+    private const string OptionalPropertiesPresent = "Present";
+    private const string OptionalPropertiesNone = "None";
+    private const string OptionalPropertiesNoneMessage = "No optional properties";
+    private static readonly EventId OptionalPropertiesLoggedEvent = new(
+        1001,
+        OptionalPropertiesEventName
+    );
+
     public async Task<List<ProcessedMatchRecord<TSource>>> ProcessAsync(
         IEnumerable<TSource> content,
         string fileName,
@@ -31,6 +42,9 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
             {
                 var person = personSpecParser.Parse(record);
                 var sourceData = reconciliationDataParser.Parse(record);
+                var loggableOptionalProperties = GetLoggableOptionalProperties(
+                    person.OptionalProperties
+                );
                 var payload = new ReconciliationRequest
                 {
                     NhsNumber = sourceData.NhsNumber,
@@ -42,7 +56,7 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
                     Phone = person.Phone,
                     Email = person.Email,
                     AddressPostalCode = person.AddressPostalCode,
-                    OptionalProperties = GetLoggableOptionalProperties(person.OptionalProperties),
+                    OptionalProperties = new Dictionary<string, object>(),
                     SearchStrategy = options.Value.SearchStrategy,
                     StrategyVersion = options.Value.StrategyVersion,
                 };
@@ -51,6 +65,9 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
                     payload,
                     cancellationToken
                 );
+
+                LogOptionalProperties(response?.SearchId, loggableOptionalProperties);
+
                 var matchingResponse = response is null
                     ? null
                     : new PersonMatchResponse
@@ -100,6 +117,44 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
 
         return processedBatch;
     }
+
+    private void LogOptionalProperties(
+        string? searchId,
+        Dictionary<string, object> optionalProperties
+    )
+    {
+        using var optionalPropertiesScope = BeginOptionalPropertiesScope(optionalProperties);
+
+        logger.LogInformation(
+            OptionalPropertiesLoggedEvent,
+            "[{EventName}] SearchId: {SearchId}, OptionalPropertiesStatus: {OptionalPropertiesStatus}, OptionalPropertiesCount: {OptionalPropertiesCount}, OptionalProperties: {OptionalProperties}",
+            OptionalPropertiesEventName,
+            searchId ?? "Unknown",
+            optionalProperties.Count == 0 ? OptionalPropertiesNone : OptionalPropertiesPresent,
+            optionalProperties.Count,
+            FormatOptionalProperties(optionalProperties)
+        );
+    }
+
+    private IDisposable? BeginOptionalPropertiesScope(Dictionary<string, object> optionalProperties)
+    {
+        if (optionalProperties.Count == 0)
+        {
+            return null;
+        }
+
+        return logger.BeginScope(
+            optionalProperties.ToDictionary(
+                optionalProperty => $"{OptionalPropertyPrefix}{optionalProperty.Key}",
+                optionalProperty => (object?)optionalProperty.Value.ToString()
+            )
+        );
+    }
+
+    private static string FormatOptionalProperties(Dictionary<string, object> optionalProperties) =>
+        optionalProperties.Count == 0
+            ? OptionalPropertiesNoneMessage
+            : JsonSerializer.Serialize(optionalProperties);
 
     private void LogAddressComparisonResult(
         string? searchId,

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Shared.Models;
 using SUI.Client.Core.Application.Interfaces;
+using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
 
 namespace SUI.Client.Core.Application.UseCases.ReconcilePeople;
@@ -12,7 +13,8 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
     IPersonSpecParser<TSource> personSpecParser,
     IReconciliationDataParser<TSource> reconciliationDataParser,
     AddressComparisonOrchestrator addressComparisonOrchestrator,
-    IOptions<PersonMatchingOptions> options
+    IOptions<PersonMatchingOptions> options,
+    IOptions<OptionalPropertiesLog> optionalPropertiesLogOptions
 ) : IMatchPersonRecordOrchestrator<TSource>
 {
     public async Task<List<ProcessedMatchRecord<TSource>>> ProcessAsync(
@@ -40,7 +42,7 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
                     Phone = person.Phone,
                     Email = person.Email,
                     AddressPostalCode = person.AddressPostalCode,
-                    OptionalProperties = person.OptionalProperties,
+                    OptionalProperties = GetLoggableOptionalProperties(person.OptionalProperties),
                     SearchStrategy = options.Value.SearchStrategy,
                     StrategyVersion = options.Value.StrategyVersion,
                 };
@@ -96,5 +98,27 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
         }
 
         return processedBatch;
+    }
+
+    private Dictionary<string, object> GetLoggableOptionalProperties(
+        Dictionary<string, object> optionalProperties
+    )
+    {
+        if (optionalProperties.Count == 0 || optionalPropertiesLogOptions.Value.Fields.Count == 0)
+        {
+            return new Dictionary<string, object>();
+        }
+
+        var allowedFields = new HashSet<string>(
+            optionalPropertiesLogOptions.Value.Fields.Keys,
+            StringComparer.OrdinalIgnoreCase
+        );
+
+        return optionalProperties
+            .Where(optionalProperty => allowedFields.Contains(optionalProperty.Key))
+            .ToDictionary(
+                optionalProperty => optionalProperty.Key,
+                optionalProperty => optionalProperty.Value
+            );
     }
 }

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -110,7 +110,7 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
         }
 
         var allowedFields = new HashSet<string>(
-            optionalPropertiesLogOptions.Value.Fields.Keys,
+            optionalPropertiesLogOptions.Value.Fields,
             StringComparer.OrdinalIgnoreCase
         );
 

--- a/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
+++ b/src/SUI.Client/SUI.Client.Core/Application/UseCases/ReconcilePeople/ReconcilePersonRecordOrchestrator.cs
@@ -63,6 +63,7 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
                     response,
                     sourceData.AddressHistory
                 );
+                LogAddressComparisonResult(response?.SearchId, addressComparison);
 
                 processedBatch.Add(
                     new ProcessedMatchRecord<TSource>
@@ -98,6 +99,21 @@ public sealed class ReconcilePersonRecordOrchestrator<TSource>(
         }
 
         return processedBatch;
+    }
+
+    private void LogAddressComparisonResult(
+        string? searchId,
+        AddressComparisonResults addressComparison
+    )
+    {
+        logger.LogInformation(
+            "[ADDRESS_COMPARISON_COMPLETED] SearchId: {SearchId}, PrimaryAddressSame: {PrimaryAddressSame}, AddressHistoriesIntersect: {AddressHistoriesIntersect}, PrimarySourceAddressInPDSHistory: {PrimarySourceAddressInPDSHistory}, PrimaryPDSAddressInSourceHistory: {PrimaryPDSAddressInSourceHistory}",
+            searchId ?? "Unknown",
+            addressComparison.PrimaryAddressSame.GetResultMessage(),
+            addressComparison.AddressHistoriesIntersect.GetResultMessage(),
+            addressComparison.PrimaryCMSAddressInPDSHistory.GetResultMessage(),
+            addressComparison.PrimaryPDSAddressInCMSHistory.GetResultMessage()
+        );
     }
 
     private Dictionary<string, object> GetLoggableOptionalProperties(

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Shared.Aspire;
 using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
@@ -21,6 +22,8 @@ using SUI.Client.StorageProcessJob.Infrastructure;
 using SUI.Client.StorageProcessJob.Infrastructure.Azure;
 
 var builder = Host.CreateApplicationBuilder(args);
+
+builder.AddTelemetryDefaults();
 
 builder
     .Services.AddOptions<StorageProcessJobOptions>()

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/Program.cs
@@ -61,6 +61,12 @@ builder
     )
     .ValidateOnStart();
 
+builder
+    .Services.AddOptions<OptionalPropertiesLog>()
+    .Bind(builder.Configuration.GetSection(OptionalPropertiesLog.SectionName))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
 builder.Services.AddSingleton(TimeProvider.System);
 
 builder.Services.AddSingleton(serviceProvider =>

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -30,5 +30,10 @@
       "NhsNumber": "SourceNumber",
       "Address": "AddressHistory"
     }
+  },
+  "OptionalPropertiesLog": {
+    "Fields": {
+      "SomeRandomField": "SomeRandomValue"
+    }
   }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -13,7 +13,7 @@
     "MessageVisibilityTimeoutMinutes": 10,
     "MessageVisibilityRenewalIntervalMinutes": 5,
     "MatchApiBaseAddress": "http://localhost:5000/matching/",
-    "ProcessingMode": "Matching"
+    "ProcessingMode": "Reconciliation"
   },
   "CsvMatchData": {
     "DateFormat": "yyyy-MM-dd",

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.Development.json
@@ -32,8 +32,8 @@
     }
   },
   "OptionalPropertiesLog": {
-    "Fields": {
-      "SomeRandomField": "SomeRandomValue"
-    }
+    "Fields": [
+      "free_school_meals"
+    ]
   }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
@@ -35,5 +35,10 @@
       "NhsNumber": "",
       "Address": ""
     }
+  },
+  "OptionalPropertiesLog": {
+    "Fields": {
+      
+    }
   }
 }

--- a/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.StorageProcessJob/appsettings.json
@@ -37,8 +37,6 @@
     }
   },
   "OptionalPropertiesLog": {
-    "Fields": {
-      
-    }
+    "Fields": []
   }
 }

--- a/src/Shared/Aspire/Extensions.cs
+++ b/src/Shared/Aspire/Extensions.cs
@@ -35,15 +35,22 @@ public static class Extensions
 
     public static IHostApplicationBuilder AddServiceDefaults(this IHostApplicationBuilder builder)
     {
-        builder.ConfigureOpenTelemetry();
+        builder.AddTelemetryDefaults();
         builder.AddDefaultHealthChecks();
-        builder.Services.AddHttpContextAccessor();
         builder.Services.AddServiceDiscovery();
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
             http.AddServiceDiscovery();
             http.AddStandardResilienceHandler();
         });
+
+        return builder;
+    }
+
+    public static IHostApplicationBuilder AddTelemetryDefaults(this IHostApplicationBuilder builder)
+    {
+        builder.Services.AddHttpContextAccessor();
+        builder.ConfigureOpenTelemetry();
 
         return builder;
     }

--- a/src/matching-api/Services/ReconciliationService.cs
+++ b/src/matching-api/Services/ReconciliationService.cs
@@ -16,8 +16,11 @@ public class ReconciliationService(
         // Check which local fields are missing
         var localMissingFields = BuildLocalMissingFields(request);
 
+        // Build a specific request for Matching. Removing non-required fields.
+        var matchingRequest = BuildMatchingRequest(request);
+
         // Match the request's demographics to an NHS number
-        var matchingResponse = await matchingService.SearchAsync(request, false);
+        var matchingResponse = await matchingService.SearchAsync(matchingRequest, false);
 
         if (string.IsNullOrWhiteSpace(matchingResponse.Result?.NhsNumber))
         {
@@ -137,6 +140,23 @@ public class ReconciliationService(
 
     private static string GetAgeGroup(DateOnly? birthDate) =>
         !birthDate.HasValue ? "Unknown" : PersonSpecificationUtils.GetAgeGroup(birthDate.Value);
+
+    private static ReconciliationRequest BuildMatchingRequest(ReconciliationRequest request) =>
+        new()
+        {
+            NhsNumber = request.NhsNumber,
+            Given = request.Given,
+            Family = request.Family,
+            BirthDate = request.BirthDate,
+            RawBirthDate = request.RawBirthDate,
+            Gender = request.Gender,
+            Phone = request.Phone,
+            Email = request.Email,
+            AddressPostalCode = request.AddressPostalCode,
+            SearchStrategy = request.SearchStrategy,
+            StrategyVersion = request.StrategyVersion,
+            OptionalProperties = new Dictionary<string, object>(),
+        };
 
     private void LogReconciliationCompleted(
         ReconciliationRequest request,

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/ModelsTests/OptionalPropertiesLogTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/ModelsTests/OptionalPropertiesLogTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Configuration;
+using SUI.Client.Core.Application.Models;
+
+namespace Unit.Tests.Client.CoreTests.ApplicationTests.ModelsTests;
+
+public class OptionalPropertiesLogTests
+{
+    [Fact]
+    public void Should_BindFields_When_ConfiguredAsArray()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    [$"{OptionalPropertiesLog.SectionName}:Fields:0"] = "free_school_meals",
+                    [$"{OptionalPropertiesLog.SectionName}:Fields:1"] = "AnotherRandomField",
+                }
+            )
+            .Build();
+
+        var options = configuration
+            .GetSection(OptionalPropertiesLog.SectionName)
+            .Get<OptionalPropertiesLog>();
+
+        Assert.NotNull(options);
+        Assert.Equal(["free_school_meals", "AnotherRandomField"], options.Fields);
+    }
+}

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -1,4 +1,4 @@
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Shared.Models;
@@ -17,6 +17,7 @@ public class ReconcilePersonRecordOrchestratorTests
         var apiClient = new Mock<IMatchingApiClient>();
         var personParser = new Mock<IPersonSpecParser<string>>();
         var reconciliationParser = new Mock<IReconciliationDataParser<string>>();
+        var logger = new Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>>();
         personParser
             .Setup(parser => parser.Parse("record"))
             .Returns(
@@ -66,7 +67,7 @@ public class ReconcilePersonRecordOrchestratorTests
                 }
             );
         var sut = new ReconcilePersonRecordOrchestrator<string>(
-            NullLogger<ReconcilePersonRecordOrchestrator<string>>.Instance,
+            logger.Object,
             apiClient.Object,
             personParser.Object,
             reconciliationParser.Object,
@@ -107,5 +108,41 @@ public class ReconcilePersonRecordOrchestratorTests
             AddressComparisonResult.AddressMatchStatus.Matched,
             result.AddressComparisonResults!.PrimaryAddressSame.Status
         );
+        VerifyAddressComparisonLogged(logger);
+    }
+
+    private static void VerifyAddressComparisonLogged(
+        Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>> logger
+    )
+    {
+        logger.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>(
+                        (state, _) => ContainsAddressComparisonLog(state.ToString()!)
+                    ),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
+    }
+
+    private static bool ContainsAddressComparisonLog(string logMessage)
+    {
+        return logMessage.Contains("[ADDRESS_COMPARISON_COMPLETED]", StringComparison.Ordinal)
+            && logMessage.Contains("SearchId: search-id", StringComparison.Ordinal)
+            && logMessage.Contains("PrimaryAddressSame: Matched", StringComparison.Ordinal)
+            && logMessage.Contains("AddressHistoriesIntersect: Matched", StringComparison.Ordinal)
+            && logMessage.Contains(
+                "PrimarySourceAddressInPDSHistory: Matched",
+                StringComparison.Ordinal
+            )
+            && logMessage.Contains(
+                "PrimaryPDSAddressInSourceHistory: Matched",
+                StringComparison.Ordinal
+            );
     }
 }

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Options;
 using Moq;
 using Shared.Models;
 using SUI.Client.Core.Application.Interfaces;
+using SUI.Client.Core.Application.Models;
 using SUI.Client.Core.Application.UseCases.MatchPeople;
 using SUI.Client.Core.Application.UseCases.ReconcilePeople;
 
@@ -26,15 +27,17 @@ public class ReconcilePersonRecordOrchestratorTests
                     BirthDate = new DateOnly(2012, 5, 10),
                     RawBirthDate = ["2012-05-10"],
                     AddressPostalCode = "AA1 1AA",
+                    OptionalProperties = new Dictionary<string, object>
+                    {
+                        ["CustomField1"] = "CustomValue1",
+                        ["CustomField2"] = "CustomValue2",
+                    },
                 }
             );
         reconciliationParser
             .Setup(parser => parser.Parse("record"))
             .Returns(
-                new ReconciliationSourceData(
-                    "9999999993",
-                    "10 Example Road, Exampletown, AA1 1AA"
-                )
+                new ReconciliationSourceData("9999999993", "10 Example Road, Exampletown, AA1 1AA")
             );
         apiClient
             .Setup(client =>
@@ -67,14 +70,18 @@ public class ReconcilePersonRecordOrchestratorTests
             apiClient.Object,
             personParser.Object,
             reconciliationParser.Object,
-            new AddressComparisonOrchestrator(
-                new SemicolonCommaNewestFirstAddressHistoryParser()
-            ),
+            new AddressComparisonOrchestrator(new SemicolonCommaNewestFirstAddressHistoryParser()),
             Options.Create(
                 new PersonMatchingOptions
                 {
                     SearchStrategy = Shared.SharedConstants.SearchStrategy.Strategies.Strategy4,
                     StrategyVersion = 2,
+                }
+            ),
+            Options.Create(
+                new OptionalPropertiesLog
+                {
+                    Fields = new Dictionary<string, string> { ["customfield1"] = string.Empty },
                 }
             )
         );
@@ -90,6 +97,8 @@ public class ReconcilePersonRecordOrchestratorTests
                         request.NhsNumber == "9999999993"
                         && request.SearchStrategy
                             == Shared.SharedConstants.SearchStrategy.Strategies.Strategy4
+                        && request.OptionalProperties.Count == 1
+                        && request.OptionalProperties["CustomField1"].Equals("CustomValue1")
                     ),
                     CancellationToken.None
                 ),

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -93,8 +93,7 @@ public class ReconcilePersonRecordOrchestratorTests
                         request.NhsNumber == "9999999993"
                         && request.SearchStrategy
                             == Shared.SharedConstants.SearchStrategy.Strategies.Strategy4
-                        && request.OptionalProperties.Count == 1
-                        && request.OptionalProperties["CustomField1"].Equals("CustomValue1")
+                        && request.OptionalProperties.Count == 0
                     ),
                     CancellationToken.None
                 ),
@@ -108,7 +107,112 @@ public class ReconcilePersonRecordOrchestratorTests
             AddressComparisonResult.AddressMatchStatus.Matched,
             result.AddressComparisonResults!.PrimaryAddressSame.Status
         );
+        VerifyOptionalPropertiesLogged(logger);
+        VerifyOptionalPropertiesScope(logger);
         VerifyAddressComparisonLogged(logger);
+    }
+
+    [Fact]
+    public async Task Should_LogNoOptionalProperties_When_NoOptionalFieldsAreLoggable()
+    {
+        var apiClient = new Mock<IMatchingApiClient>();
+        var personParser = new Mock<IPersonSpecParser<string>>();
+        var reconciliationParser = new Mock<IReconciliationDataParser<string>>();
+        var logger = new Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>>();
+        personParser
+            .Setup(parser => parser.Parse("record"))
+            .Returns(
+                new PersonSpecification
+                {
+                    Given = "Jane",
+                    Family = "Doe",
+                    BirthDate = new DateOnly(2012, 5, 10),
+                    RawBirthDate = ["2012-05-10"],
+                    AddressPostalCode = "AA1 1AA",
+                    OptionalProperties = new Dictionary<string, object>
+                    {
+                        ["CustomField2"] = "CustomValue2",
+                    },
+                }
+            );
+        reconciliationParser
+            .Setup(parser => parser.Parse("record"))
+            .Returns(new ReconciliationSourceData("9999999993", null));
+        apiClient
+            .Setup(client =>
+                client.ReconcilePersonAsync(
+                    It.IsAny<ReconciliationRequest>(),
+                    CancellationToken.None
+                )
+            )
+            .ReturnsAsync(
+                new ReconciliationResponse
+                {
+                    Status = ReconciliationStatus.NoDifferences,
+                    SearchId = "search-id",
+                    MatchingResult = new MatchResult { MatchStatus = MatchStatus.Match },
+                }
+            );
+        var sut = new ReconcilePersonRecordOrchestrator<string>(
+            logger.Object,
+            apiClient.Object,
+            personParser.Object,
+            reconciliationParser.Object,
+            new AddressComparisonOrchestrator(new SemicolonCommaNewestFirstAddressHistoryParser()),
+            Options.Create(new PersonMatchingOptions()),
+            Options.Create(new OptionalPropertiesLog { Fields = ["customfield1"] })
+        );
+
+        await sut.ProcessAsync(["record"], "input.csv", CancellationToken.None);
+
+        VerifyNoOptionalPropertiesLogged(logger);
+    }
+
+    private static void VerifyOptionalPropertiesLogged(
+        Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>> logger
+    )
+    {
+        logger.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Information,
+                    It.Is<EventId>(eventId => ContainsOptionalPropertiesEventId(eventId)),
+                    It.Is<It.IsAnyType>((state, _) => ContainsOptionalPropertiesLogState(state)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
+    }
+
+    private static void VerifyNoOptionalPropertiesLogged(
+        Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>> logger
+    )
+    {
+        logger.Verify(
+            x =>
+                x.Log(
+                    LogLevel.Information,
+                    It.Is<EventId>(eventId => ContainsOptionalPropertiesEventId(eventId)),
+                    It.Is<It.IsAnyType>((state, _) => ContainsNoOptionalPropertiesLogState(state)),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()
+                ),
+            Times.Once
+        );
+    }
+
+    private static void VerifyOptionalPropertiesScope(
+        Mock<ILogger<ReconcilePersonRecordOrchestrator<string>>> logger
+    )
+    {
+        logger.Verify(
+            x =>
+                x.BeginScope(
+                    It.Is<It.IsAnyType>((state, _) => ContainsOptionalPropertiesScope(state))
+                ),
+            Times.Once
+        );
     }
 
     private static void VerifyAddressComparisonLogged(
@@ -128,6 +232,96 @@ public class ReconcilePersonRecordOrchestratorTests
                 ),
             Times.Once
         );
+    }
+
+    private static bool ContainsOptionalPropertiesLogState(object state)
+    {
+        if (state is not IEnumerable<KeyValuePair<string, object?>> logProperties)
+        {
+            return false;
+        }
+
+        var properties = logProperties.ToDictionary(
+            logProperty => logProperty.Key,
+            logProperty => logProperty.Value
+        );
+
+        return HasLogProperty(properties, "EventName", "RECONCILIATION_OPTIONAL_PROPERTIES")
+            && HasLogProperty(properties, "SearchId", "search-id")
+            && HasLogProperty(properties, "OptionalPropertiesStatus", "Present")
+            && HasLogProperty(properties, "OptionalPropertiesCount", "1")
+            && HasLogProperty(
+                properties,
+                "OptionalProperties",
+                """{"CustomField1":"CustomValue1"}"""
+            )
+            && ContainsOptionalPropertiesMessage(state.ToString()!);
+    }
+
+    private static bool ContainsOptionalPropertiesEventId(EventId eventId)
+    {
+        return eventId.Id == 1001
+            && string.Equals(
+                eventId.Name,
+                "RECONCILIATION_OPTIONAL_PROPERTIES",
+                StringComparison.Ordinal
+            );
+    }
+
+    private static bool ContainsNoOptionalPropertiesLogState(object state)
+    {
+        if (state is not IEnumerable<KeyValuePair<string, object?>> logProperties)
+        {
+            return false;
+        }
+
+        var properties = logProperties.ToDictionary(
+            logProperty => logProperty.Key,
+            logProperty => logProperty.Value
+        );
+
+        return HasLogProperty(properties, "EventName", "RECONCILIATION_OPTIONAL_PROPERTIES")
+            && HasLogProperty(properties, "SearchId", "search-id")
+            && HasLogProperty(properties, "OptionalPropertiesStatus", "None")
+            && HasLogProperty(properties, "OptionalPropertiesCount", "0")
+            && HasLogProperty(properties, "OptionalProperties", "No optional properties")
+            && state.ToString()!.Contains("No optional properties", StringComparison.Ordinal);
+    }
+
+    private static bool ContainsOptionalPropertiesScope(object state)
+    {
+        if (state is not IEnumerable<KeyValuePair<string, object?>> scopeProperties)
+        {
+            return false;
+        }
+
+        var properties = scopeProperties.ToDictionary(
+            scopeProperty => scopeProperty.Key,
+            scopeProperty => scopeProperty.Value
+        );
+
+        return HasLogProperty(properties, "Optional_CustomField1", "CustomValue1")
+            && !properties.ContainsKey("Optional_CustomField2");
+    }
+
+    private static bool ContainsOptionalPropertiesMessage(string message)
+    {
+        return message.Contains(
+                """OptionalProperties: {"CustomField1":"CustomValue1"}""",
+                StringComparison.Ordinal
+            )
+            && !message.Contains("CustomField2", StringComparison.Ordinal)
+            && !message.Contains("CustomValue2", StringComparison.Ordinal);
+    }
+
+    private static bool HasLogProperty(
+        IReadOnlyDictionary<string, object?> properties,
+        string key,
+        string expectedValue
+    )
+    {
+        return properties.TryGetValue(key, out var actualValue)
+            && string.Equals(actualValue?.ToString(), expectedValue, StringComparison.Ordinal);
     }
 
     private static bool ContainsAddressComparisonLog(string logMessage)

--- a/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
+++ b/tests/Unit.Tests/Client/CoreTests/ApplicationTests/UseCaseTests/ReconcilePeopleTests/ReconcilePersonRecordOrchestratorTests.cs
@@ -78,12 +78,7 @@ public class ReconcilePersonRecordOrchestratorTests
                     StrategyVersion = 2,
                 }
             ),
-            Options.Create(
-                new OptionalPropertiesLog
-                {
-                    Fields = new Dictionary<string, string> { ["customfield1"] = string.Empty },
-                }
-            )
+            Options.Create(new OptionalPropertiesLog { Fields = ["customfield1"] })
         );
 
         var result = Assert.Single(

--- a/tests/Unit.Tests/Matching/ReconciliationServiceTests/ReconcileAsyncTests.cs
+++ b/tests/Unit.Tests/Matching/ReconciliationServiceTests/ReconcileAsyncTests.cs
@@ -2,6 +2,7 @@ using MatchingApi.Services;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Shared;
 using Shared.Endpoint;
 using Shared.Models;
 
@@ -15,6 +16,65 @@ public class ReconcileAsyncTests
     public const string ValidNhsNumber = "9449305552";
     private const string InvalidNhsNumber = "1234567890";
     private const string SearchId = "test-search-id";
+
+    [Fact]
+    public async Task Should_SendEmptyOptionalPropertiesToMatchingService_WhenRequestContainsOptionalProperties()
+    {
+        // Arrange
+        var request = new ReconciliationRequest
+        {
+            NhsNumber = ValidNhsNumber,
+            AddressPostalCode = "AA11 2BB",
+            Family = "Hamilton",
+            Given = "David",
+            Gender = "Male",
+            Phone = "123454321",
+            BirthDate = new DateOnly(1990, 01, 02),
+            RawBirthDate = ["1990-01-02"],
+            Email = "david.hamilton@example.com",
+            SearchStrategy = SharedConstants.SearchStrategy.Strategies.Strategy2,
+            StrategyVersion = 2,
+            OptionalProperties = new Dictionary<string, object> { ["CustomField"] = "CustomValue" },
+        };
+        SearchSpecification? matchingRequest = null;
+
+        _matchingService
+            .Setup(x => x.SearchAsync(It.IsAny<SearchSpecification>(), false))
+            .Callback<SearchSpecification, bool>((sentRequest, _) => matchingRequest = sentRequest)
+            .ReturnsAsync(
+                new PersonMatchResponse
+                {
+                    SearchId = SearchId,
+                    Result = new MatchResult { MatchStatus = MatchStatus.NoMatch, NhsNumber = "" },
+                }
+            );
+
+        var sut = new ReconciliationService(
+            _matchingService.Object,
+            NullLogger<ReconciliationService>.Instance,
+            _nhsFhirClient.Object
+        );
+
+        // Act
+        await sut.ReconcileAsync(request);
+
+        // Assert
+        Assert.NotNull(matchingRequest);
+        Assert.NotSame(request, matchingRequest);
+        Assert.Empty(matchingRequest.OptionalProperties);
+        Assert.Equal("CustomValue", request.OptionalProperties["CustomField"]);
+        Assert.Equal(request.NhsNumber, ((ReconciliationRequest)matchingRequest).NhsNumber);
+        Assert.Equal(request.AddressPostalCode, matchingRequest.AddressPostalCode);
+        Assert.Equal(request.Family, matchingRequest.Family);
+        Assert.Equal(request.Given, matchingRequest.Given);
+        Assert.Equal(request.Gender, matchingRequest.Gender);
+        Assert.Equal(request.Phone, matchingRequest.Phone);
+        Assert.Equal(request.BirthDate, matchingRequest.BirthDate);
+        Assert.Equal(request.RawBirthDate, matchingRequest.RawBirthDate);
+        Assert.Equal(request.Email, matchingRequest.Email);
+        Assert.Equal(request.SearchStrategy, matchingRequest.SearchStrategy);
+        Assert.Equal(request.StrategyVersion, matchingRequest.StrategyVersion);
+    }
 
     [Fact]
     public async Task ReconcileAsync_WhenLocalDemographicsDidNotMatch_ReturnCorrectStatusAndNoDifferences()


### PR DESCRIPTION
## Summary

All changes effect the reconcilaition mode. Added additional logging of optional configurable properties. Added logging of the address result.
All logs contain SearchId so correlating should be straight forward.

## Changes

- Removed sending optional logging in matching API on reconciliation. All the logging we need can be done from the client and is not used for anything else in matching.
- Add optional properties white list to log. White list is so that we can securely enable logging only what is expected. Any fields not expected are not logged.
- Added the Address logical outcome to the log as well
- Fix: apply app insights to the storage blob processor - had a missing connection string

## Validation

- Run all tests and created new tests for new code
- Run az bicep files through local validation
- Run the app locally with test files. Confirmed that expected fields are logged and unexpected fields are not logged.
