### PR TITLE
Update dependabot configuration with cooldown settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     labels:
       - github-actions
       - dependabot
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semvar-patch-days: 2
+      


### PR DESCRIPTION
Reduces supply chain risks to the repository, by waiting some time before applying new versions, in case a supply chain attack occurs and remedial steps are taken.

Raised by Hippo security reporting.