### PR TITLE
SUI-1820 - Write Confident matches back to eclipse

### DIFF
--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 using Eclipse.GraphQL;
 
 using Microsoft.Extensions.Logging;
@@ -19,15 +21,18 @@ public class GraphQlProcessor(
     IOptions<GraphQlProcessJobOptions> options,
     IOptions<CsvMatchDataOptions> csvMatchDataOptions)
 {
+    private record PersonMetadata(int ObjectVersion, string? NhsNumber, IReadOnlyList<PersonType> PersonTypes);
+
     public async Task RunAsync(CancellationToken cancellationToken)
     {
+        var timer = Stopwatch.StartNew();
         logger.LogInformation("Running Graph QL Process Job.");
         var mappings = csvMatchDataOptions.Value.ColumnMappings;
 
-        var (csvRecords, personObjectVersions) = await FetchAndCompilePersonRecordsAsync(mappings, cancellationToken);
+        (List<CsvRecordDto> csvRecords, Dictionary<string, PersonMetadata> personMetadata) = await FetchAndCompilePersonRecordsAsync(mappings, cancellationToken);
 
-        logger.LogInformation("Completed compiling GraphQL records. Total records retrieved: {Count}.",
-            csvRecords.Count);
+        logger.LogInformation("Completed compiling GraphQL records. Total records retrieved: {Count}. Elapsed Time: {ElapsedTime}",
+            csvRecords.Count, timer.Elapsed.ToString("g"));
 
         var matchedResults = await matchPersonRecordOrchestrator.ProcessAsync(
             csvRecords,
@@ -36,23 +41,25 @@ public class GraphQlProcessor(
         );
 
         logger.LogInformation(
-            "Finished processing matching with orchestrator. Result count: {Count}. Matches: {MatchCount}",
+            "Finished processing matching. Result count: {Count}. Matches: {MatchCount}. Elapsed time: {ElapsedTime}",
             matchedResults.Count, matchedResults.Count(x => x.ApiResult is
             {
                 Result.IsHighConfidenceMatch: true
-            }));
+            }), timer.Elapsed.ToString("g"));
 
-        await SaveMatchedNhsNumbersAsync(matchedResults, personObjectVersions, mappings, cancellationToken);
+        await SaveMatchedNhsNumbersAsync(matchedResults, personMetadata, mappings, cancellationToken);
+
+        logger.LogInformation("GraphQL Job Complete. Total time: {ElapsedTime}", timer.Elapsed.ToString("g"));
     }
 
-    private async Task<(List<CsvRecordDto> CsvRecords, Dictionary<string, int> PersonObjectVersions)> FetchAndCompilePersonRecordsAsync(
+    private async Task<(List<CsvRecordDto> CsvRecords, Dictionary<string, PersonMetadata> PersonMetadata)> FetchAndCompilePersonRecordsAsync(
         CsvMatchDataOptions.Headers mappings,
         CancellationToken cancellationToken)
     {
         int pageNumber = 1;
-        const int pageSize = 10;
+        const int pageSize = 100;
         var csvRecords = new List<CsvRecordDto>();
-        var personObjectVersions = new Dictionary<string, int>();
+        var personMetadata = new Dictionary<string, PersonMetadata>();
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -70,12 +77,23 @@ public class GraphQlProcessor(
             {
                 if (result is IPersonByCriteria_PersonByCriteria_Results_Person person)
                 {
-                    personObjectVersions[person.Id] = person.ObjectVersion;
+                    personMetadata[person.Id] = new PersonMetadata(
+                        person.ObjectVersion,
+                        person.NhsNumber,
+                        person.PersonTypes ?? []
+                    );
                     csvRecords.Add(new CsvRecordDto(MapPersonToDictionary(person, mappings)));
                 }
             }
 
             var cursor = results.Data?.PersonByCriteria?.Cursor;
+            if (cursor != null && logger.IsEnabled(LogLevel.Information))
+            {
+                logger.LogInformation(
+                    "Processed Page: {Page}. Page size: {PageSize}. Total Records: {TotalRecords}",
+                    cursor.PageNumber, cursor.PageSize, cursor.TotalSize);
+            }
+
             if (cursor == null || cursor.Offset + cursor.Returned >= cursor.TotalSize)
             {
                 break;
@@ -84,7 +102,7 @@ public class GraphQlProcessor(
             pageNumber++;
         }
 
-        return (csvRecords, personObjectVersions);
+        return (csvRecords, personMetadata);
     }
 
     private Dictionary<string, string> MapPersonToDictionary(
@@ -118,7 +136,7 @@ public class GraphQlProcessor(
 
     private async Task SaveMatchedNhsNumbersAsync(
         IEnumerable<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
-        Dictionary<string, int> personObjectVersions,
+        Dictionary<string, PersonMetadata> personMetadata,
         CsvMatchDataOptions.Headers mappings,
         CancellationToken cancellationToken)
     {
@@ -127,20 +145,28 @@ public class GraphQlProcessor(
             if (result.ApiResult is not { Result.IsHighConfidenceMatch: true } ||
                 string.IsNullOrEmpty(result.ApiResult.Result.NhsNumber))
             {
+                logger.LogInformation("Match is low confidence, Skipping update.");
                 continue;
             }
 
             var personId = result.OriginalData.Record[mappings.Id];
             var matchedNhsNumber = result.ApiResult.Result.NhsNumber;
 
-            if (!personObjectVersions.TryGetValue(personId, out var objectVersion))
+            if (!personMetadata.TryGetValue(personId, out var metadata))
             {
-                logger.LogWarning("Could not find ObjectVersion for Person {PersonId}. Skipping NHS number update.", personId);
+                logger.LogWarning("Could not find metadata for Person {PersonId}. Skipping NHS number update.", personId);
+                continue;
+            }
+
+            if (!string.IsNullOrEmpty(metadata.NhsNumber))
+            {
+                logger.LogInformation("Person {PersonId} already has NHS number {ExistingNhsNumber}. Skipping update.",
+                    personId, metadata.NhsNumber);
                 continue;
             }
 
             logger.LogInformation("Saving matched NHS number {NhsNumber} for Person {PersonId} with ObjectVersion {ObjectVersion}.",
-                matchedNhsNumber, personId, objectVersion);
+                matchedNhsNumber, personId, metadata.ObjectVersion);
 
             try
             {
@@ -148,7 +174,8 @@ public class GraphQlProcessor(
                 {
                     Id = personId,
                     NhsNumber = matchedNhsNumber,
-                    ObjectVersion = objectVersion
+                    ObjectVersion = metadata.ObjectVersion,
+                    PersonTypes = metadata.PersonTypes
                 };
 
                 var updateResult = await eclipseClient.UpdatePerson.ExecuteAsync(updateInput, cancellationToken);

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
@@ -21,15 +21,13 @@ public class GraphQlProcessor(
     IOptions<GraphQlProcessJobOptions> options,
     IOptions<CsvMatchDataOptions> csvMatchDataOptions)
 {
-    private record PersonMetadata(int ObjectVersion, string? NhsNumber, IReadOnlyList<PersonType> PersonTypes);
-
     public async Task RunAsync(CancellationToken cancellationToken)
     {
         var timer = Stopwatch.StartNew();
         logger.LogInformation("Running Graph QL Process Job.");
         var mappings = csvMatchDataOptions.Value.ColumnMappings;
 
-        (List<CsvRecordDto> csvRecords, Dictionary<string, PersonMetadata> personMetadata) = await FetchAndCompilePersonRecordsAsync(mappings, cancellationToken);
+        List<CsvRecordDto> csvRecords = await FetchAndCompilePersonRecordsAsync(mappings, cancellationToken);
 
         logger.LogInformation("Completed compiling GraphQL records. Total records retrieved: {Count}. Elapsed Time: {ElapsedTime}",
             csvRecords.Count, timer.Elapsed.ToString("g"));
@@ -47,19 +45,18 @@ public class GraphQlProcessor(
                 Result.IsHighConfidenceMatch: true
             }), timer.Elapsed.ToString("g"));
 
-        await SaveMatchedNhsNumbersAsync(matchedResults, personMetadata, mappings, cancellationToken);
+        await SaveMatchedNhsNumbersAsync(matchedResults, mappings, cancellationToken);
 
         logger.LogInformation("GraphQL Job Complete. Total time: {ElapsedTime}", timer.Elapsed.ToString("g"));
     }
 
-    private async Task<(List<CsvRecordDto> CsvRecords, Dictionary<string, PersonMetadata> PersonMetadata)> FetchAndCompilePersonRecordsAsync(
+    private async Task<List<CsvRecordDto>> FetchAndCompilePersonRecordsAsync(
         CsvMatchDataOptions.Headers mappings,
         CancellationToken cancellationToken)
     {
         int pageNumber = 1;
         const int pageSize = 100;
         var csvRecords = new List<CsvRecordDto>();
-        var personMetadata = new Dictionary<string, PersonMetadata>();
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -77,11 +74,6 @@ public class GraphQlProcessor(
             {
                 if (result is IPersonByCriteria_PersonByCriteria_Results_Person person)
                 {
-                    personMetadata[person.Id] = new PersonMetadata(
-                        person.ObjectVersion,
-                        person.NhsNumber,
-                        person.PersonTypes ?? []
-                    );
                     csvRecords.Add(new CsvRecordDto(MapPersonToDictionary(person, mappings)));
                 }
             }
@@ -102,7 +94,7 @@ public class GraphQlProcessor(
             pageNumber++;
         }
 
-        return (csvRecords, personMetadata);
+        return csvRecords;
     }
 
     private Dictionary<string, string> MapPersonToDictionary(
@@ -115,7 +107,9 @@ public class GraphQlProcessor(
             { mappings.Given, person.Forename ?? "" },
             { mappings.Family, person.Surname ?? "" },
             { mappings.BirthDate, person.DateOfBirth?.Lower?.ToString(csvMatchDataOptions.Value.DateFormat) ?? "" },
-            { mappings.Postcode, GetPreferredPostcode(person) }
+            { mappings.Postcode, GetPreferredPostcode(person) },
+            { "__ObjectVersion", person.ObjectVersion.ToString() },
+            { "__PersonTypes", string.Join(",", person.PersonTypes ?? []) }
         };
 
         if (!string.IsNullOrEmpty(mappings.NhsNumber))
@@ -136,7 +130,6 @@ public class GraphQlProcessor(
 
     private async Task SaveMatchedNhsNumbersAsync(
         IEnumerable<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
-        Dictionary<string, PersonMetadata> personMetadata,
         CsvMatchDataOptions.Headers mappings,
         CancellationToken cancellationToken)
     {
@@ -145,37 +138,51 @@ public class GraphQlProcessor(
             if (result.ApiResult is not { Result.IsHighConfidenceMatch: true } ||
                 string.IsNullOrEmpty(result.ApiResult.Result.NhsNumber))
             {
-                logger.LogInformation("Match is low confidence, Skipping update.");
                 continue;
             }
 
             var personId = result.OriginalData.Record[mappings.Id];
             var matchedNhsNumber = result.ApiResult.Result.NhsNumber;
 
-            if (!personMetadata.TryGetValue(personId, out var metadata))
+            var existingNhsNumber = !string.IsNullOrEmpty(mappings.NhsNumber) &&
+                                    result.OriginalData.Record.TryGetValue(mappings.NhsNumber, out var extNhs)
+                                    ? extNhs
+                                    : null;
+
+            if (!string.IsNullOrEmpty(existingNhsNumber))
             {
-                logger.LogWarning("Could not find metadata for Person {PersonId}. Skipping NHS number update.", personId);
+                logger.LogInformation("Person {PersonId} already has NHS number. Skipping update.",
+                    personId);
                 continue;
             }
 
-            if (!string.IsNullOrEmpty(metadata.NhsNumber))
+            if (!result.OriginalData.Record.TryGetValue("__ObjectVersion", out var objVerStr) ||
+                !int.TryParse(objVerStr, out var objectVersion))
             {
-                logger.LogInformation("Person {PersonId} already has NHS number {ExistingNhsNumber}. Skipping update.",
-                    personId, metadata.NhsNumber);
+                logger.LogWarning("Could not find ObjectVersion for Person {PersonId}. Skipping NHS number update.", personId);
                 continue;
             }
 
             logger.LogInformation("Saving matched NHS number {NhsNumber} for Person {PersonId} with ObjectVersion {ObjectVersion}.",
-                matchedNhsNumber, personId, metadata.ObjectVersion);
+                matchedNhsNumber, personId, objectVersion);
 
             try
             {
+                var personTypesList = new List<PersonType>();
+                if (result.OriginalData.Record.TryGetValue("__PersonTypes", out var typesStr) &&
+                    !string.IsNullOrEmpty(typesStr))
+                {
+                    personTypesList = typesStr.Split(',', StringSplitOptions.RemoveEmptyEntries)
+                        .Select(Enum.Parse<PersonType>)
+                        .ToList();
+                }
+
                 var updateInput = new UpdatePerson
                 {
                     Id = personId,
                     NhsNumber = matchedNhsNumber,
-                    ObjectVersion = metadata.ObjectVersion,
-                    PersonTypes = metadata.PersonTypes
+                    ObjectVersion = objectVersion,
+                    PersonTypes = personTypesList
                 };
 
                 var updateResult = await eclipseClient.UpdatePerson.ExecuteAsync(updateInput, cancellationToken);

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/Infrastructure/GraphQLProcessor.cs
@@ -7,6 +7,7 @@ using StrawberryShake;
 
 using SUI.Client.Core.Application.Interfaces;
 using SUI.Client.Core.Application.Models;
+using SUI.Client.Core.Application.UseCases.MatchPeople;
 using SUI.Client.Core.Infrastructure.CsvParsers;
 
 namespace SUI.Client.GraphQLProcessJob.Infrastructure;
@@ -21,68 +22,9 @@ public class GraphQlProcessor(
     public async Task RunAsync(CancellationToken cancellationToken)
     {
         logger.LogInformation("Running Graph QL Process Job.");
-        int pageNumber = 1;
-        const int pageSize = 10;
-        bool hasMoreResults = true;
-        var csvRecords = new List<CsvRecordDto>();
         var mappings = csvMatchDataOptions.Value.ColumnMappings;
 
-        while (hasMoreResults && !cancellationToken.IsCancellationRequested)
-        {
-            var results = await eclipseClient.PersonByCriteria.ExecuteAsync(options.Value.MaxAge,
-                new RequestCursorInput { PageNumber = pageNumber, PageSize = pageSize }, cancellationToken);
-            results.EnsureNoErrors();
-
-            if (results.Data?.PersonByCriteria?.Results is { Count: > 0 } resultsList)
-            {
-                foreach (var result in resultsList)
-                {
-                    if (result is not IPersonByCriteria_PersonByCriteria_Results_Person person)
-                    {
-                        continue;
-                    }
-
-                    var personDictionary = new Dictionary<string, string>
-                    {
-                        { mappings.Id, person.Id },
-                        { mappings.Given, person.Forename ?? "" },
-                        { mappings.Family, person.Surname ?? "" },
-                        { mappings.BirthDate, person.DateOfBirth?.Lower?.ToString(csvMatchDataOptions.Value.DateFormat) ?? "" },
-                        {
-                            mappings.Postcode,
-                            person.Addresses.FirstOrDefault(a => a.Id == person.PreferredAddress?.Id)?.Location
-                                ?.Postcode ?? ""
-                        }
-                    };
-
-                    if (!string.IsNullOrEmpty(mappings.NhsNumber))
-                    {
-                        personDictionary[mappings.NhsNumber] = person.NhsNumber ?? "";
-                    }
-
-                    if (!string.IsNullOrEmpty(mappings.Gender))
-                    {
-                        personDictionary[mappings.Gender] = person.Gender?.ToString().ToLower() ?? "";
-                    }
-
-                    csvRecords.Add(new CsvRecordDto(personDictionary));
-                }
-
-                var cursor = results.Data?.PersonByCriteria?.Cursor;
-                if (cursor != null && cursor.Offset + cursor.Returned < cursor.TotalSize)
-                {
-                    pageNumber++;
-                }
-                else
-                {
-                    hasMoreResults = false;
-                }
-            }
-            else
-            {
-                hasMoreResults = false;
-            }
-        }
+        var (csvRecords, personObjectVersions) = await FetchAndCompilePersonRecordsAsync(mappings, cancellationToken);
 
         logger.LogInformation("Completed compiling GraphQL records. Total records retrieved: {Count}.",
             csvRecords.Count);
@@ -99,5 +41,125 @@ public class GraphQlProcessor(
             {
                 Result.IsHighConfidenceMatch: true
             }));
+
+        await SaveMatchedNhsNumbersAsync(matchedResults, personObjectVersions, mappings, cancellationToken);
+    }
+
+    private async Task<(List<CsvRecordDto> CsvRecords, Dictionary<string, int> PersonObjectVersions)> FetchAndCompilePersonRecordsAsync(
+        CsvMatchDataOptions.Headers mappings,
+        CancellationToken cancellationToken)
+    {
+        int pageNumber = 1;
+        const int pageSize = 10;
+        var csvRecords = new List<CsvRecordDto>();
+        var personObjectVersions = new Dictionary<string, int>();
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var results = await eclipseClient.PersonByCriteria.ExecuteAsync(options.Value.MaxAge,
+                new RequestCursorInput { PageNumber = pageNumber, PageSize = pageSize }, cancellationToken);
+            results.EnsureNoErrors();
+
+            var resultsList = results.Data?.PersonByCriteria?.Results;
+            if (resultsList == null || resultsList.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var result in resultsList)
+            {
+                if (result is IPersonByCriteria_PersonByCriteria_Results_Person person)
+                {
+                    personObjectVersions[person.Id] = person.ObjectVersion;
+                    csvRecords.Add(new CsvRecordDto(MapPersonToDictionary(person, mappings)));
+                }
+            }
+
+            var cursor = results.Data?.PersonByCriteria?.Cursor;
+            if (cursor == null || cursor.Offset + cursor.Returned >= cursor.TotalSize)
+            {
+                break;
+            }
+
+            pageNumber++;
+        }
+
+        return (csvRecords, personObjectVersions);
+    }
+
+    private Dictionary<string, string> MapPersonToDictionary(
+        IPersonByCriteria_PersonByCriteria_Results_Person person,
+        CsvMatchDataOptions.Headers mappings)
+    {
+        var personDictionary = new Dictionary<string, string>
+        {
+            { mappings.Id, person.Id },
+            { mappings.Given, person.Forename ?? "" },
+            { mappings.Family, person.Surname ?? "" },
+            { mappings.BirthDate, person.DateOfBirth?.Lower?.ToString(csvMatchDataOptions.Value.DateFormat) ?? "" },
+            { mappings.Postcode, GetPreferredPostcode(person) }
+        };
+
+        if (!string.IsNullOrEmpty(mappings.NhsNumber))
+        {
+            personDictionary[mappings.NhsNumber] = person.NhsNumber ?? "";
+        }
+
+        if (!string.IsNullOrEmpty(mappings.Gender))
+        {
+            personDictionary[mappings.Gender] = person.Gender?.ToString().ToLower() ?? "";
+        }
+
+        return personDictionary;
+    }
+
+    private static string GetPreferredPostcode(IPersonByCriteria_PersonByCriteria_Results_Person person) =>
+        person.Addresses.FirstOrDefault(a => a.Id == person.PreferredAddress?.Id)?.Location?.Postcode ?? "";
+
+    private async Task SaveMatchedNhsNumbersAsync(
+        IEnumerable<ProcessedMatchRecord<CsvRecordDto>> matchedResults,
+        Dictionary<string, int> personObjectVersions,
+        CsvMatchDataOptions.Headers mappings,
+        CancellationToken cancellationToken)
+    {
+        foreach (var result in matchedResults)
+        {
+            if (result.ApiResult is not { Result.IsHighConfidenceMatch: true } ||
+                string.IsNullOrEmpty(result.ApiResult.Result.NhsNumber))
+            {
+                continue;
+            }
+
+            var personId = result.OriginalData.Record[mappings.Id];
+            var matchedNhsNumber = result.ApiResult.Result.NhsNumber;
+
+            if (!personObjectVersions.TryGetValue(personId, out var objectVersion))
+            {
+                logger.LogWarning("Could not find ObjectVersion for Person {PersonId}. Skipping NHS number update.", personId);
+                continue;
+            }
+
+            logger.LogInformation("Saving matched NHS number {NhsNumber} for Person {PersonId} with ObjectVersion {ObjectVersion}.",
+                matchedNhsNumber, personId, objectVersion);
+
+            try
+            {
+                var updateInput = new UpdatePerson
+                {
+                    Id = personId,
+                    NhsNumber = matchedNhsNumber,
+                    ObjectVersion = objectVersion
+                };
+
+                var updateResult = await eclipseClient.UpdatePerson.ExecuteAsync(updateInput, cancellationToken);
+                updateResult.EnsureNoErrors();
+
+                logger.LogInformation("Successfully saved NHS number for Person {PersonId}.", personId);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to save NHS number for Person {PersonId}.", personId);
+            }
+        }
     }
 }

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/PersonByCriteria.graphql
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/PersonByCriteria.graphql
@@ -23,6 +23,7 @@ query PersonByCriteria($maxAge: Int, $paging: RequestCursorInput) {
                 }
                 id
                 objectVersion
+                personTypes
                 forename
                 surname
                 gender

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/PersonByCriteria.graphql
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/PersonByCriteria.graphql
@@ -22,6 +22,7 @@ query PersonByCriteria($maxAge: Int, $paging: RequestCursorInput) {
                     mask
                 }
                 id
+                objectVersion
                 forename
                 surname
                 gender

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/UpdatePerson.graphql
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/UpdatePerson.graphql
@@ -1,0 +1,7 @@
+mutation UpdatePerson($input: UpdatePerson!) {
+    updatePerson(input: $input) {
+        id
+        objectVersion
+        nhsNumber
+    }
+}

--- a/src/SUI.Client/SUI.Client.GraphQLProcessJob/appsettings.json
+++ b/src/SUI.Client/SUI.Client.GraphQLProcessJob/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "System.Net.Http.HttpClient": "Error"
     }
   },
   "GraphQlProcessJob": {

--- a/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
+++ b/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
@@ -882,6 +882,7 @@ public class GraphQlProcessorTests
         var personMock = new Mock<IPersonByCriteria_PersonByCriteria_Results_Person>();
         personMock.Setup(p => p.Id).Returns("person-123");
         personMock.Setup(p => p.ObjectVersion).Returns(5);
+        personMock.Setup(p => p.PersonTypes).Returns(new List<PersonType> { PersonType.Client });
         personMock.Setup(p => p.Forename).Returns("John");
         personMock.Setup(p => p.Surname).Returns("Doe");
         personMock.Setup(p => p.DateOfBirth).Returns((IPersonByCriteria_PersonByCriteria_Results_DateOfBirth?)null);
@@ -940,8 +941,101 @@ public class GraphQlProcessorTests
                 It.Is<global::Eclipse.GraphQL.UpdatePerson>(input =>
                     input.Id == "person-123" &&
                     input.NhsNumber == "9999999999" &&
-                    input.ObjectVersion == 5),
+                    input.ObjectVersion == 5 &&
+                    input.PersonTypes != null &&
+                    input.PersonTypes.Count == 1 &&
+                    input.PersonTypes[0] == PersonType.Client),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task RunAsync_ShouldNotCallUpdatePersonMutation_WhenPersonAlreadyHasNhsNumber()
+    {
+        // Arrange
+        var options = Options.Create(new GraphQlProcessJobOptions { MaxAge = 25 });
+
+        var updatePersonResultMock = new Mock<IUpdatePersonResult>();
+        var operationUpdateResultMock = new Mock<IOperationResult<IUpdatePersonResult>>();
+        operationUpdateResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
+        operationUpdateResultMock.Setup(r => r.Data).Returns(updatePersonResultMock.Object);
+
+        var updatePersonMutationMock = new Mock<IUpdatePersonMutation>();
+        updatePersonMutationMock
+            .Setup(m => m.ExecuteAsync(It.IsAny<global::Eclipse.GraphQL.UpdatePerson>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operationUpdateResultMock.Object);
+
+        _eclipseClientMock.Setup(c => c.UpdatePerson).Returns(updatePersonMutationMock.Object);
+
+        var sut = new GraphQlProcessor(
+            _loggerMock.Object,
+            _eclipseClientMock.Object,
+            _matchPersonRecordOrchestratorMock.Object,
+            options,
+            _csvMatchOptions
+        );
+
+        // Person already has NHS number "1111111111"
+        var personMock = new Mock<IPersonByCriteria_PersonByCriteria_Results_Person>();
+        personMock.Setup(p => p.Id).Returns("person-123");
+        personMock.Setup(p => p.NhsNumber).Returns("1111111111");
+        personMock.Setup(p => p.ObjectVersion).Returns(5);
+        personMock.Setup(p => p.Forename).Returns("John");
+        personMock.Setup(p => p.Surname).Returns("Doe");
+        personMock.Setup(p => p.DateOfBirth).Returns((IPersonByCriteria_PersonByCriteria_Results_DateOfBirth?)null);
+        personMock.Setup(p => p.Addresses).Returns(new List<IPersonByCriteria_PersonByCriteria_Results_Addresses>());
+        personMock.Setup(p => p.PreferredAddress).Returns((IPersonByCriteria_PersonByCriteria_Results_PreferredAddress?)null);
+
+        var resultsList = new List<IPersonByCriteria_PersonByCriteria_Results> { personMock.Object };
+
+        var cursorMock = new Mock<IPersonByCriteria_PersonByCriteria_Cursor>();
+        cursorMock.Setup(c => c.Offset).Returns(0);
+        cursorMock.Setup(c => c.Returned).Returns(1);
+        cursorMock.Setup(c => c.TotalSize).Returns(1);
+
+        var personByCriteriaMock = new Mock<IPersonByCriteria_PersonByCriteria>();
+        personByCriteriaMock.Setup(p => p.Results).Returns(resultsList.AsReadOnly());
+        personByCriteriaMock.Setup(p => p.Cursor).Returns(cursorMock.Object);
+
+        var operationResultDataMock = new Mock<IPersonByCriteriaResult>();
+        operationResultDataMock.Setup(o => o.PersonByCriteria).Returns(personByCriteriaMock.Object);
+
+        var operationResultMock = new Mock<IOperationResult<IPersonByCriteriaResult>>();
+        operationResultMock.Setup(r => r.Data).Returns(operationResultDataMock.Object);
+        operationResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
+
+        _personByCriteriaQueryMock
+            .Setup(q => q.ExecuteAsync(It.IsAny<int>(), It.IsAny<RequestCursorInput>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operationResultMock.Object);
+
+        var matchResult = new Shared.Models.MatchResult
+        {
+            MatchStatus = Shared.Models.MatchStatus.Match,
+            NhsNumber = "9999999999",
+            Score = 1.0m
+        };
+        var apiResult = new Shared.Models.PersonMatchResponse
+        {
+            Result = matchResult
+        };
+
+        var matchedRecord = new ProcessedMatchRecord<CsvRecordDto>
+        {
+            OriginalData = new CsvRecordDto(new Dictionary<string, string> { { "SourceID", "person-123" } }),
+            ApiResult = apiResult,
+            IsSuccess = true
+        };
+
+        _matchPersonRecordOrchestratorMock
+            .Setup(o => o.ProcessAsync(It.IsAny<IEnumerable<CsvRecordDto>>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ProcessedMatchRecord<CsvRecordDto>> { matchedRecord });
+
+        // Act
+        await sut.RunAsync(CancellationToken.None);
+
+        // Assert - Verify that ExecuteAsync is NEVER called because the person already has an NHS number
+        updatePersonMutationMock.Verify(
+            m => m.ExecuteAsync(It.IsAny<global::Eclipse.GraphQL.UpdatePerson>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }

--- a/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
+++ b/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
@@ -852,4 +852,96 @@ public class GraphQlProcessorTests
         Assert.False(record.Record.ContainsKey("NHSNumber"));
         Assert.False(record.Record.ContainsKey("Gender"));
     }
+
+    [Fact]
+    public async Task RunAsync_ShouldCallUpdatePersonMutation_WhenHighConfidenceMatchIsReturned()
+    {
+        // Arrange
+        var options = Options.Create(new GraphQlProcessJobOptions { MaxAge = 25 });
+
+        var updatePersonResultMock = new Mock<IUpdatePersonResult>();
+        var operationUpdateResultMock = new Mock<IOperationResult<IUpdatePersonResult>>();
+        operationUpdateResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
+        operationUpdateResultMock.Setup(r => r.Data).Returns(updatePersonResultMock.Object);
+
+        var updatePersonMutationMock = new Mock<IUpdatePersonMutation>();
+        updatePersonMutationMock
+            .Setup(m => m.ExecuteAsync(It.IsAny<global::Eclipse.GraphQL.UpdatePerson>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operationUpdateResultMock.Object);
+
+        _eclipseClientMock.Setup(c => c.UpdatePerson).Returns(updatePersonMutationMock.Object);
+
+        var sut = new GraphQlProcessor(
+            _loggerMock.Object,
+            _eclipseClientMock.Object,
+            _matchPersonRecordOrchestratorMock.Object,
+            options,
+            _csvMatchOptions
+        );
+
+        var personMock = new Mock<IPersonByCriteria_PersonByCriteria_Results_Person>();
+        personMock.Setup(p => p.Id).Returns("person-123");
+        personMock.Setup(p => p.ObjectVersion).Returns(5);
+        personMock.Setup(p => p.Forename).Returns("John");
+        personMock.Setup(p => p.Surname).Returns("Doe");
+        personMock.Setup(p => p.DateOfBirth).Returns((IPersonByCriteria_PersonByCriteria_Results_DateOfBirth?)null);
+        personMock.Setup(p => p.Addresses).Returns(new List<IPersonByCriteria_PersonByCriteria_Results_Addresses>());
+        personMock.Setup(p => p.PreferredAddress)
+            .Returns((IPersonByCriteria_PersonByCriteria_Results_PreferredAddress?)null);
+
+        var resultsList = new List<IPersonByCriteria_PersonByCriteria_Results> { personMock.Object };
+
+        var cursorMock = new Mock<IPersonByCriteria_PersonByCriteria_Cursor>();
+        cursorMock.Setup(c => c.Offset).Returns(0);
+        cursorMock.Setup(c => c.Returned).Returns(1);
+        cursorMock.Setup(c => c.TotalSize).Returns(1);
+
+        var personByCriteriaMock = new Mock<IPersonByCriteria_PersonByCriteria>();
+        personByCriteriaMock.Setup(p => p.Results).Returns(resultsList.AsReadOnly());
+        personByCriteriaMock.Setup(p => p.Cursor).Returns(cursorMock.Object);
+
+        var operationResultDataMock = new Mock<IPersonByCriteriaResult>();
+        operationResultDataMock.Setup(o => o.PersonByCriteria).Returns(personByCriteriaMock.Object);
+
+        var operationResultMock = new Mock<IOperationResult<IPersonByCriteriaResult>>();
+        operationResultMock.Setup(r => r.Data).Returns(operationResultDataMock.Object);
+        operationResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
+
+        _personByCriteriaQueryMock
+            .Setup(q => q.ExecuteAsync(It.IsAny<int>(), It.IsAny<RequestCursorInput>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(operationResultMock.Object);
+
+        var matchResult = new Shared.Models.MatchResult
+        {
+            MatchStatus = Shared.Models.MatchStatus.Match,
+            NhsNumber = "9999999999",
+            Score = 1.0m
+        };
+        var apiResult = new Shared.Models.PersonMatchResponse { Result = matchResult };
+
+        var matchedRecord = new ProcessedMatchRecord<CsvRecordDto>
+        {
+            OriginalData = new CsvRecordDto(new Dictionary<string, string> { { "SourceID", "person-123" } }),
+            ApiResult = apiResult,
+            IsSuccess = true
+        };
+
+        _matchPersonRecordOrchestratorMock
+            .Setup(o => o.ProcessAsync(It.IsAny<IEnumerable<CsvRecordDto>>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ProcessedMatchRecord<CsvRecordDto>> { matchedRecord });
+
+        // Act
+        await sut.RunAsync(CancellationToken.None);
+
+        // Assert
+        updatePersonMutationMock.Verify(
+            m => m.ExecuteAsync(
+                It.Is<global::Eclipse.GraphQL.UpdatePerson>(input =>
+                    input.Id == "person-123" &&
+                    input.NhsNumber == "9999999999" &&
+                    input.ObjectVersion == 5),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
+++ b/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
@@ -922,7 +922,13 @@ public class GraphQlProcessorTests
 
         var matchedRecord = new ProcessedMatchRecord<CsvRecordDto>
         {
-            OriginalData = new CsvRecordDto(new Dictionary<string, string> { { "SourceID", "person-123" } }),
+            OriginalData = new CsvRecordDto(new Dictionary<string, string>
+            {
+                { "SourceID", "person-123" },
+                { "__ObjectVersion", "5" },
+                { "NHSNumber", "" },
+                { "__PersonTypes", "Client" }
+            }),
             ApiResult = apiResult,
             IsSuccess = true
         };
@@ -1021,7 +1027,13 @@ public class GraphQlProcessorTests
 
         var matchedRecord = new ProcessedMatchRecord<CsvRecordDto>
         {
-            OriginalData = new CsvRecordDto(new Dictionary<string, string> { { "SourceID", "person-123" } }),
+            OriginalData = new CsvRecordDto(new Dictionary<string, string>
+            {
+                { "SourceID", "person-123" },
+                { "__ObjectVersion", "5" },
+                { "NHSNumber", "1111111111" },
+                { "__PersonTypes", "Client" }
+            }),
             ApiResult = apiResult,
             IsSuccess = true
         };

--- a/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
+++ b/tests/Unit.Tests/Client/GraphQlProcessJob/GraphQlProcessorTests.cs
@@ -95,7 +95,7 @@ public class GraphQlProcessorTests
         operationResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
 
         _personByCriteriaQueryMock
-            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 10),
+            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 100),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(operationResultMock.Object);
 
@@ -198,12 +198,12 @@ public class GraphQlProcessorTests
 
         // Setup query mock to return Page 1 first, then Page 2
         _personByCriteriaQueryMock
-            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 10),
+            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 100),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(operationResultMock1.Object);
 
         _personByCriteriaQueryMock
-            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 2 && r.PageSize == 10),
+            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 2 && r.PageSize == 100),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(operationResultMock2.Object);
 
@@ -278,7 +278,7 @@ public class GraphQlProcessorTests
         operationResultMock.Setup(r => r.Errors).Returns(new List<IClientError>());
 
         _personByCriteriaQueryMock
-            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 10),
+            .Setup(q => q.ExecuteAsync(25, It.Is<RequestCursorInput>(r => r.PageNumber == 1 && r.PageSize == 100),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(operationResultMock.Object);
 

--- a/tests/tools/FakeEclipseGraphQLApi/Models/Person.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Models/Person.cs
@@ -12,6 +12,7 @@ public class Person : IPersonByCriteria_PersonByCriteria_Results
     public string? Gender { get; set; }
     public string? NhsNumber { get; set; }
     public int ObjectVersion { get; set; } = 1;
+    public List<PersonType> PersonTypes { get; set; } = new() { PersonType.CLIENT };
     public DateRange? DateOfBirth { get; set; }
     public List<Address> Addresses { get; set; } = new();
     public Address? PreferredAddress { get; set; }

--- a/tests/tools/FakeEclipseGraphQLApi/Models/Person.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Models/Person.cs
@@ -11,6 +11,7 @@ public class Person : IPersonByCriteria_PersonByCriteria_Results
     public string? Surname { get; set; }
     public string? Gender { get; set; }
     public string? NhsNumber { get; set; }
+    public int ObjectVersion { get; set; } = 1;
     public DateRange? DateOfBirth { get; set; }
     public List<Address> Addresses { get; set; } = new();
     public Address? PreferredAddress { get; set; }

--- a/tests/tools/FakeEclipseGraphQLApi/Models/PersonType.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Models/PersonType.cs
@@ -1,0 +1,10 @@
+namespace FakeEclipseGraphQLApi.Models;
+
+public enum PersonType
+{
+    ADOPTER,
+    CLIENT,
+    FOSTER_CARER,
+    OTHER,
+    PROFESSIONAL
+}

--- a/tests/tools/FakeEclipseGraphQLApi/Models/UpdatePerson.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Models/UpdatePerson.cs
@@ -14,4 +14,6 @@ public class UpdatePerson
     public string? NhsNumber { get; set; }
 
     public int ObjectVersion { get; set; }
+
+    public List<PersonType>? PersonTypes { get; set; }
 }

--- a/tests/tools/FakeEclipseGraphQLApi/Models/UpdatePerson.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Models/UpdatePerson.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.CodeAnalysis;
+
+using HotChocolate;
+
+namespace FakeEclipseGraphQLApi.Models;
+
+[ExcludeFromCodeCoverage]
+[InputObjectType(Name = "UpdatePerson")]
+public class UpdatePerson
+{
+    [GraphQLType(typeof(NonNullType<IdType>))]
+    public string Id { get; set; } = string.Empty;
+
+    public string? NhsNumber { get; set; }
+
+    public int ObjectVersion { get; set; }
+}

--- a/tests/tools/FakeEclipseGraphQLApi/Mutation.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Mutation.cs
@@ -41,6 +41,8 @@ public class Mutation
         }
 
         person.NhsNumber = input.NhsNumber;
+        var updatedObjectVersion = person.ObjectVersion + 1;
+        person.ObjectVersion = updatedObjectVersion;
 
         var updatedJson = JsonSerializer.Serialize(response, options);
 

--- a/tests/tools/FakeEclipseGraphQLApi/Mutation.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Mutation.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+using FakeEclipseGraphQLApi.Models;
+
+namespace FakeEclipseGraphQLApi;
+
+[ExcludeFromCodeCoverage]
+public class Mutation
+{
+    public Person UpdatePerson(UpdatePerson input)
+    {
+        var filePath = System.IO.Path.Combine(AppContext.BaseDirectory, "data", "personByCriteria.json");
+        if (!File.Exists(filePath))
+        {
+            filePath = System.IO.Path.Combine("data", "personByCriteria.json");
+        }
+
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException($"Mock data file not found at: {filePath}");
+        }
+
+        var json = File.ReadAllText(filePath);
+        var options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true
+        };
+        var response = JsonSerializer.Deserialize<PersonResults>(json, options);
+
+        if (response == null || response.Results == null)
+        {
+            throw new InvalidOperationException("Failed to load and deserialize person data.");
+        }
+
+        var person = response.Results.FirstOrDefault(p => p.Id == input.Id);
+        if (person == null)
+        {
+            throw new ArgumentException($"Person with ID '{input.Id}' not found.");
+        }
+
+        person.NhsNumber = input.NhsNumber;
+
+        var updatedJson = JsonSerializer.Serialize(response, options);
+
+        File.WriteAllText(filePath, updatedJson);
+
+        return person;
+    }
+}

--- a/tests/tools/FakeEclipseGraphQLApi/Program.cs
+++ b/tests/tools/FakeEclipseGraphQLApi/Program.cs
@@ -7,6 +7,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services
     .AddGraphQLServer()
     .AddQueryType<Query>()
+    .AddMutationType<Mutation>()
     .AddUnionType<IPersonByCriteria_PersonByCriteria_Results>()
     .AddType<Person>();
 

--- a/tests/tools/FakeEclipseGraphQLApi/data/personByCriteria.json
+++ b/tests/tools/FakeEclipseGraphQLApi/data/personByCriteria.json
@@ -13,7 +13,11 @@
       "Forename": "OCTAVIA",
       "Surname": "CHISLETT",
       "Gender": "FEMALE",
-      "NhsNumber": "9449305552",
+      "NhsNumber": "9691292211",
+      "ObjectVersion": 3,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2008-09-20",
         "Upper": "2008-09-20",
@@ -28,7 +32,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-12345678"
+        "Id": "addr-12345678",
+        "Location": null
       }
     },
     {
@@ -38,6 +43,10 @@
       "Surname": "FORMBY",
       "Gender": "MALE",
       "NhsNumber": "9691914913",
+      "ObjectVersion": 1,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2005-06-03",
         "Upper": "2005-06-03",
@@ -52,7 +61,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-12323232"
+        "Id": "addr-12323232",
+        "Location": null
       }
     },
     {
@@ -62,6 +72,10 @@
       "Surname": "FORMBY",
       "Gender": "MALE",
       "NhsNumber": "9691914913",
+      "ObjectVersion": 1,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2005-06-03",
         "Upper": "2005-06-03",
@@ -76,7 +90,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-12323232-2"
+        "Id": "addr-12323232-2",
+        "Location": null
       }
     },
     {
@@ -86,6 +101,10 @@
       "Surname": "chislett",
       "Gender": "MALE",
       "NhsNumber": "9449310424",
+      "ObjectVersion": 1,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2008-09-20",
         "Upper": "2008-09-20",
@@ -100,7 +119,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-34556655"
+        "Id": "addr-34556655",
+        "Location": null
       }
     },
     {
@@ -110,6 +130,10 @@
       "Surname": "chislett",
       "Gender": "MALE",
       "NhsNumber": "0449310999",
+      "ObjectVersion": 1,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2008-09-20",
         "Upper": "2008-09-20",
@@ -124,7 +148,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-34567655"
+        "Id": "addr-34567655",
+        "Location": null
       }
     },
     {
@@ -134,6 +159,10 @@
       "Surname": "Missing MHS Number",
       "Gender": "MALE",
       "NhsNumber": "",
+      "ObjectVersion": 1,
+      "PersonTypes": [
+        1
+      ],
       "DateOfBirth": {
         "Lower": "2008-09-20",
         "Upper": "2008-09-20",
@@ -148,7 +177,8 @@
         }
       ],
       "PreferredAddress": {
-        "Id": "addr-34568855"
+        "Id": "addr-34568855",
+        "Location": null
       }
     }
   ]


### PR DESCRIPTION

<!--
Ensure PR title follows the conventional commit format with a ticket reference:
<type>: SUI-1234 - concise description
-->

## Summary

<!--
Describe the intent of the PR at a high level:
- what problem or need this change addresses
- why this approach was taken
- any important scope or non-goals if they matter for review
-->
added UpdatePerson mutation to save strong match NHS numbers back to eclipse.
Refactored GraphQLProcessor

## Changes

<!--
List the concrete changes in reviewer-friendly bullets.
Keep this focused on the meaningful implementation/documentation changes.
-->

- split GraphQlProcessor method up to reduce complexity
- added mutation to save back nhs numbers

## Validation

<!--
List how you validated the change.
Examples:
- Unit/integration/E2E tests run
- Manual validation steps
- Terraform plan/apply environments
- Docs-only change; no code/runtime validation required
-->

- unit tests
- run against fake api

<!--
Optional: add extra context below when relevant, for example:
- deferred findings or follow-up work
- rollout notes
- known limitations
- reviewer-specific context
-->
