### PR TITLE
feat: add additional logging for tracing

### DIFF
--- a/src/external-api/Services/FhirClientFactory.cs
+++ b/src/external-api/Services/FhirClientFactory.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Http.Headers;
 using Hl7.Fhir.Rest;
@@ -10,8 +11,11 @@ public interface IFhirClientFactory
 }
 
 [ExcludeFromCodeCoverage(Justification = "Cannot test third party library")]
-public class FhirClientFactory(ITokenService tokenService, IConfiguration config)
-    : IFhirClientFactory
+public class FhirClientFactory(
+    ILogger<FhirClientFactory> logger,
+    ITokenService tokenService,
+    IConfiguration config
+) : IFhirClientFactory
 {
     public FhirClient CreateFhirClient()
     {
@@ -26,7 +30,16 @@ public class FhirClientFactory(ITokenService tokenService, IConfiguration config
                 "Bearer",
                 accessToken
             );
-            fhirClient.RequestHeaders.Add("X-Request-ID", Guid.NewGuid().ToString());
+
+            // This traceRequestId is not sensitive and is only used for tracing between us and PDS
+            var pdsTraceRequestId = Guid.NewGuid().ToString();
+#pragma warning disable CA1873
+            // Not necessary, but useful if the AddTag method is not working for some reason.
+            logger.LogInformation("PDS Trace Request ID: {TraceRequestId}", pdsTraceRequestId);
+#pragma warning restore CA1873
+            // This will show on dependency logs in Application Insights and can be used to correlate requests between us and PDS
+            Activity.Current?.AddTag("PdsTraceRequestId", pdsTraceRequestId);
+            fhirClient.RequestHeaders.Add("X-Request-ID", pdsTraceRequestId);
         }
 
         return fhirClient;


### PR DESCRIPTION
## Summary

If we need to use trace logging between PDS and ourselves, then we need to be able to retrieve those trace ids through logging.

## Changes

- Added the traceId as a variable and passed to both standard logging (for local debugging) and the activity diagnostics for app insights.
-
-

## Validation

- I can see the logs locally with the expected trace id outcome.

This has not been tested in deployed environment as the risk is low that it won't work. Standard logging at the least will pick it up.
