### PR TITLE
fix: vulnerabilities nuget openapi

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,7 @@ updates:
         patterns:
           - "*"
     cooldown:
-      semver-major-days: 30
-      semver-minor-days: 7
-      semver-patch-days: 7
+      default-days: 7
 
   - package-ecosystem: nuget
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,35 @@
 version: 2
 updates:
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: 'daily'
-    labels:
-      - github-actions
-      - dependabot
+      interval: "weekly"
+      day: "tuesday"
+      time: "06:00"
+    commit-message:
+      prefix: "[gha]-"
+    groups:
+      github-actions-updates:
+        patterns:
+          - "*"
     cooldown:
       semver-major-days: 30
       semver-minor-days: 7
-      semvar-patch-days: 2
-      
+      semver-patch-days: 7
+
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "06:00"
+    commit-message:
+      prefix: "[nuget][SUI_Matcher]-"
+    groups:
+      SUI-package-updates:
+        patterns:
+          - "*"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 7

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.AspNet.WebApi.Core" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="$(AspnetVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.10" />
     <PackageVersion Include="HotChocolate.AspNetCore" Version="14.1.0" />
     <PackageVersion Include="StrawberryShake.Server" Version="16.2.0" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="10.1.7" />
@@ -78,7 +78,7 @@
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.2.1" />
     <PackageVersion Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
     <PackageVersion Include="Microsoft.IdentityModel.Tokens" Version="8.14.0" />
-    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
     <PackageVersion Include="OxyPlot.Core" Version="2.2.0" />
     <PackageVersion Include="OxyPlot.SkiaSharp" Version="2.2.0" />
     <PackageVersion Include="QuestPDF" Version="2025.7.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,10 @@
     <PackageVersion Include="Azure.Storage.Queues" Version="12.25.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="2.51.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.7" />
-    <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues" Version="5.5.4" />
+    <PackageVersion
+      Include="Microsoft.Azure.Functions.Worker.Extensions.Storage.Queues"
+      Version="5.5.4"
+    />
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="FluentAssertions" Version="8.6.0" />
     <PackageVersion Include="Hl7.Fhir.R4" Version="6.0.0-rc1" />
@@ -36,19 +39,40 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUi" Version="10.1.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.ApiDescription.Server" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.ApiDescription.Server"
+      Version="$(AspnetVersion)"
+    />
+    <PackageVersion
+      Include="Microsoft.Extensions.Configuration.Abstractions"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.Configuration.Binder"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.DependencyInjection.Abstractions"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.Hosting.WindowsServices"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.Hosting.Abstractions"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(AspnetVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="$(AspnetVersion)" />
+    <PackageVersion
+      Include="Microsoft.Extensions.Logging.Abstractions"
+      Version="$(AspnetVersion)"
+    />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="$(AspnetVersion)" />
     <PackageVersion Include="Microsoft.FeatureManagement" Version="4.2.1" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.2.1" />
@@ -92,11 +116,17 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Abstractions" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Yarp" Version="10.4.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.4.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion
+      Include="OpenTelemetry.Instrumentation.AspNetCore"
+      Version="$(OpenTelemetryVersion)"
+    />
+    <PackageVersion
+      Include="OpenTelemetry.Instrumentation.Http"
+      Version="$(OpenTelemetryVersion)"
+    />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Healthchecks -->


### PR DESCRIPTION
<!--
Ensure PR title follows the conventional commit format with a ticket reference:
<type>: SUI-1234 - concise description
-->

## Summary

Update some packages in non test projects that are showing vulnerabilities.

## Changes

- 2 high severity packages in opentelemetry and openapi
- Updated dependabot.yml to include nuget.
-

## Validation

run the following to show no vulnerabilities.
dotnet restore
dotnet list src/external-api/External.csproj package --include-transitive --vulnerable
dotnet list src/matching-api/Matching.csproj package --include-transitive --vulnerable
dotnet list src/matching-api/Matching.csproj package --include-transitive --vulnerable

<!--
Optional: add extra context below when relevant, for example:
- deferred findings or follow-up work
- rollout notes
- known limitations
- reviewer-specific context
-->
