### PR TITLE
chore: 1955 -  remove mass transit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,6 @@
     <AspireVersion>13.1.2</AspireVersion>
     <OpenTelemetryVersion>1.14.0</OpenTelemetryVersion>
     <AspVersioningVersion>10.0.0</AspVersioningVersion>
-    <MassTransitVersion>9.1.2</MassTransitVersion>
     <MartenVersion>8.8.1</MartenVersion>
   </PropertyGroup>
   <ItemGroup>
@@ -89,7 +88,6 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="MassTransit" Version="$(MassTransitVersion)" />
     <PackageVersion Include="Marten.AspNetCore" Version="$(MartenVersion)" />
     <PackageVersion Include="Marten" Version="$(MartenVersion)" />
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.3.0" />

--- a/documentation/docs/architecture.md
+++ b/documentation/docs/architecture.md
@@ -127,8 +127,8 @@ C4Container
 
     Container_Boundary(c1, "Sui Matching Service") {
         Container(reverse_proxy, "Gateway", "C#, .NET 8, YARP", "The reverse proxy/API gateway of the SUI matcher.")
-        Container(matching_api, "Matching APIs", "C#, .NET 8, MassTransit", "The barista service.")
-        Container(auth_api, "Auth APIs", "C#, .NET 8, MassTransit", "The authentication service.")
+        Container(matching_api, "Matching APIs", "C#, .NET 10, ASP.NET Core", "The barista service.")
+        Container(auth_api, "Auth APIs", "C#, .NET 10, ASP.NET Core", "The authentication service.")
         Container(external_api, "External Services", "C#, .NET 8, Marten", "Makes the outbound connections for other services")
 
         Boundary(b1, "Docker containers", "boundary") {

--- a/documentation/docs/architecture.md
+++ b/documentation/docs/architecture.md
@@ -126,10 +126,10 @@ C4Container
     System(laclient, "Local Authority Client", "The client to connect to the service")
 
     Container_Boundary(c1, "Sui Matching Service") {
-        Container(reverse_proxy, "Gateway", "C#, .NET 8, YARP", "The reverse proxy/API gateway of the SUI matcher.")
+        Container(reverse_proxy, "Gateway", "C#, .NET 10, YARP", "The reverse proxy/API gateway of the SUI matcher.")
         Container(matching_api, "Matching APIs", "C#, .NET 10, ASP.NET Core", "The barista service.")
         Container(auth_api, "Auth APIs", "C#, .NET 10, ASP.NET Core", "The authentication service.")
-        Container(external_api, "External Services", "C#, .NET 8, Marten", "Makes the outbound connections for other services")
+        Container(external_api, "External Services", "C#, .NET 10, Marten", "Makes the outbound connections for other services")
 
         Boundary(b1, "Docker containers", "boundary") {
             ContainerDb(cache, "Storage", "Redis", "Stores bearer tokens for auth")

--- a/src/Shared/Aspire/Extensions.cs
+++ b/src/Shared/Aspire/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Azure.Monitor.OpenTelemetry.AspNetCore;
-using MassTransit.Logging;
-using MassTransit.Monitoring;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -80,7 +78,6 @@ public static class Extensions
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
                     .AddRuntimeInstrumentation()
-                    .AddMeter(InstrumentationOptions.MeterName)
                     .AddMeter("Marten");
             })
             .WithTracing(tracing =>
@@ -88,7 +85,6 @@ public static class Extensions
                 tracing
                     .AddAspNetCoreInstrumentation()
                     .AddHttpClientInstrumentation()
-                    .AddSource(DiagnosticHeaders.DefaultListenerName)
                     .AddSource("Marten")
                     .AddSource("Yarp.ReverseProxy");
             });

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -4,7 +4,6 @@
     <PackageReference Include="Aspire.Azure.Data.Tables" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" />
     <PackageReference Include="DotNetEnv" />
-    <PackageReference Include="MassTransit" />
     <PackageReference Include="Microsoft.FeatureManagement" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Remove unused MassTransit dependencies and telemetry configuration. The use of MassTransit appears to have been a very old idea and usage that is no longer used or makes sense.

## Changes

 - Removed MassTransit package and telemetry references.
 - Updated architecture documentation to reflect .NET 10.

 ## Validation

  - dotnet build sui-matching.sln passed.
  - All tests passed